### PR TITLE
Improve mobile loading speed for horizontal rise and search results

### DIFF
--- a/styles/modern.css
+++ b/styles/modern.css
@@ -406,6 +406,14 @@ Rejected premiere wordmark variant:
         --mm-reveal-delay: 0ms !important;
         --mm-reveal-duration: 250ms !important;
     }
+    
+    .animate-fade-in, .animate-slide-up {
+        animation-duration: 0.25s !important;
+    }
+    
+    .animate-scale-up {
+        animation-duration: 0.2s !important;
+    }
 }
 
 .mm-action-feedback {

--- a/styles/modern.css
+++ b/styles/modern.css
@@ -401,6 +401,13 @@ Rejected premiere wordmark variant:
     transform: none;
 }
 
+@media (max-width: 768px) {
+    .mm-reveal {
+        --mm-reveal-delay: 0ms !important;
+        --mm-reveal-duration: 250ms !important;
+    }
+}
+
 .mm-action-feedback {
     will-change: transform, box-shadow, filter;
 }


### PR DESCRIPTION
This pull request adds responsive adjustments to animation timings for mobile devices in the `styles/modern.css` file. The main goal is to ensure that reveal and animation effects are faster and smoother on screens 768px wide or less.

**Responsive animation timing improvements:**

* Added a media query for screens with a max width of 768px to reduce the delay and duration of the `.mm-reveal` animation and to shorten the durations of `.animate-fade-in`, `.animate-slide-up`, and `.animate-scale-up` animations.