### PR TITLE
Improve cloud folder management and caching logic

### DIFF
--- a/hooks/useCloudWatchlists.ts
+++ b/hooks/useCloudWatchlists.ts
@@ -69,33 +69,48 @@ export function useCloudWatchlists() {
   const [cloudFolders, setCloudFolders] = useState<WatchlistFolder[]>([]);
   const [cloudLoading, setCloudLoading] = useState(false);
   const cloudCacheHydratedUserRef = useRef<string | null>(null);
+  const cloudFoldersOwnerRef = useRef<string | null>(null);
+  const activeCloudUserIdRef = useRef<string | null>(null);
+
+  const setCloudFoldersForUser = useCallback((userId: string, folders: WatchlistFolder[]) => {
+    cloudFoldersOwnerRef.current = userId;
+    setCloudFolders(folders);
+  }, []);
 
   const refreshCloud = useCallback(async () => {
-    if (!user?.id || !isSupabaseConfigured) return;
+    const userId = user?.id;
+    if (!userId || !isSupabaseConfigured) return;
     setCloudLoading(true);
     try {
-      const folders = applyWatchlistOrder(await fetchCloudWatchlists(user.id), loadWatchlistOrderState(localStorage));
-      setCloudFolders(folders);
+      const folders = applyWatchlistOrder(await fetchCloudWatchlists(userId), loadWatchlistOrderState(localStorage));
+      if (activeCloudUserIdRef.current !== userId) return;
+      setCloudFoldersForUser(userId, folders);
     } catch (error) {
       console.warn('Failed to refresh cloud watchlists', error);
     } finally {
       setCloudLoading(false);
     }
-  }, [user?.id]);
+  }, [setCloudFoldersForUser, user?.id]);
 
   useEffect(() => {
     if (!user?.id || !isSupabaseConfigured) {
+      activeCloudUserIdRef.current = null;
+      cloudFoldersOwnerRef.current = null;
       setCloudFolders([]);
       cloudCacheHydratedUserRef.current = null;
       return;
     }
+    activeCloudUserIdRef.current = user.id;
+    cloudFoldersOwnerRef.current = null;
+    setCloudFolders([]);
+
     const cached = readCloudCache(user.id);
     if (cached.length > 0) {
-      setCloudFolders(cached);
+      setCloudFoldersForUser(user.id, cached);
     }
     cloudCacheHydratedUserRef.current = user.id;
     refreshCloud();
-  }, [user?.id, refreshCloud]);
+  }, [refreshCloud, setCloudFoldersForUser, user?.id]);
 
   useEffect(() => {
     if (!user?.id || !isSupabaseConfigured) return;
@@ -109,6 +124,7 @@ export function useCloudWatchlists() {
   useEffect(() => {
     if (!user?.id || !isSupabaseConfigured) return;
     if (cloudCacheHydratedUserRef.current !== user.id) return;
+    if (cloudFoldersOwnerRef.current !== user.id) return;
     writeCloudCache(user.id, cloudFolders);
   }, [cloudFolders, user?.id]);
 

--- a/styles/search-results-page.css
+++ b/styles/search-results-page.css
@@ -508,12 +508,14 @@ html[data-card-density="compact"] .search-result-body {
   opacity: 0;
   transform: translateY(4px);
   transition: opacity 0.2s ease, transform 0.2s ease;
+  pointer-events: none;
 }
 
 .search-result-card:hover .search-result-feedback-strip,
 .search-result-card:focus-within .search-result-feedback-strip {
   opacity: 1;
   transform: translateY(0);
+  pointer-events: auto;
 }
 
 .search-result-feedback-btn {


### PR DESCRIPTION
This pull request improves the reliability of the cloud watchlist syncing logic and enhances the user experience for search result interactions. The main focus is on preventing stale or out-of-sync data from being written to the cloud cache and ensuring UI elements behave as expected.

**Cloud watchlist state management improvements:**

* Added `cloudFoldersOwnerRef` and `activeCloudUserIdRef` refs to track which user's folders are currently being managed, preventing race conditions and stale data from being set or written to the cache. Introduced a `setCloudFoldersForUser` helper to encapsulate this logic.
* Updated the effect that writes to the cloud cache to only proceed if both the hydrated cache and the folder owner match the current user, further protecting against accidental cache overwrites.

**Search results UI improvements:**

* Modified the `.search-result-feedback-strip` CSS to use `pointer-events: none` by default, and enable pointer events only on hover/focus. This prevents invisible feedback strips from intercepting clicks, improving usability in compact card density mode.