### PR TITLE
Enhance caching mechanism with entity indexing and validation

### DIFF
--- a/__tests__/integration/userJourneySmoke.test.ts
+++ b/__tests__/integration/userJourneySmoke.test.ts
@@ -6,6 +6,8 @@ const mockFetch = jest.fn();
 
 jest.mock('../../services/cacheService', () => ({
   getCachedResponse: jest.fn().mockReturnValue(null),
+  getCachedByEntity: jest.fn().mockReturnValue(null),
+  resolveEntityFromQuery: jest.fn().mockReturnValue(null),
   cacheResponse: jest.fn(),
   clearOldCacheEntries: jest.fn()
 }));

--- a/__tests__/services/cacheService.test.ts
+++ b/__tests__/services/cacheService.test.ts
@@ -1,0 +1,104 @@
+import {
+  cacheResponse,
+  getCachedByEntity,
+  getCachedResponse,
+  linkQueryToEntity,
+  resolveEntityFromQuery,
+  clearAllCache
+} from '../../services/cacheService';
+import type { MovieData } from '../../types';
+
+function installMockLocalStorage(): void {
+  const store = new Map<string, string>();
+  const mockStorage: Storage = {
+    get length() {
+      return store.size;
+    },
+    clear: () => {
+      store.clear();
+    },
+    getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value));
+    }
+  };
+
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: mockStorage,
+    configurable: true,
+    writable: true
+  });
+}
+
+function createMovieData(overrides: Partial<MovieData> = {}): MovieData {
+  return {
+    tmdb_id: '603',
+    title: 'The Matrix',
+    year: '1999',
+    type: 'movie',
+    media_type: 'movie',
+    genres: ['Science Fiction'],
+    poster_url: 'https://example.com/poster.jpg',
+    backdrop_url: 'https://example.com/backdrop.jpg',
+    trailer_url: 'https://youtube.com/watch?v=x',
+    ratings: [],
+    cast: [],
+    crew: { director: 'Wachowski', writer: 'Wachowski', music: 'Davis' },
+    summary_short: 'Short summary',
+    summary_medium: 'Medium summary',
+    summary_long_spoilers: 'Long summary',
+    suspense_breaker: 'Twist',
+    where_to_watch: [],
+    extra_images: [],
+    ai_notes: 'AI notes',
+    ...overrides
+  };
+}
+
+describe('cacheService entity-first caching', () => {
+  beforeEach(() => {
+    installMockLocalStorage();
+    clearAllCache();
+  });
+
+  it('stores and resolves query-to-entity mapping', () => {
+    linkQueryToEntity('matrix', 'groq', 'movie', '603');
+
+    const resolved = resolveEntityFromQuery('matrix', 'groq');
+    expect(resolved).toEqual({ media_type: 'movie', tmdb_id: '603' });
+  });
+
+  it('writes entity cache when caching a query and can read by entity key', () => {
+    const movie = createMovieData();
+
+    cacheResponse('matrix', 'groq', movie, null);
+
+    const entityCached = getCachedByEntity('groq', 'movie', '603');
+    expect(entityCached).not.toBeNull();
+    expect(entityCached?.movieData.title).toBe('The Matrix');
+  });
+
+  it('supports entity-first retrieval across different queries for same title', () => {
+    const movie = createMovieData();
+
+    cacheResponse('matrix 1999', 'groq', movie, null);
+    linkQueryToEntity('neo blue pill movie', 'groq', 'movie', '603');
+
+    const cached = getCachedResponse('neo blue pill movie', 'groq');
+    expect(cached).not.toBeNull();
+    expect(cached?.movieData.tmdb_id).toBe('603');
+  });
+
+  it('backfills entity mapping from legacy query cache payload', () => {
+    const movie = createMovieData();
+
+    cacheResponse('the matrix film', 'groq', movie, null);
+
+    const resolved = resolveEntityFromQuery('the matrix film', 'groq');
+    expect(resolved).toEqual({ media_type: 'movie', tmdb_id: '603' });
+  });
+});

--- a/services/aiService.ts
+++ b/services/aiService.ts
@@ -1,7 +1,13 @@
 import { ChatMessage, MovieData, QueryComplexity, FetchResult, AIProvider } from '../types';
 import { fetchMovieData as fetchFromGroq } from './groqService';
 import { fetchMovieData as fetchFromPerplexity } from './perplexityService';
-import { getCachedResponse, cacheResponse, clearOldCacheEntries } from './cacheService';
+import {
+  getCachedResponse,
+  cacheResponse,
+  clearOldCacheEntries,
+  resolveEntityFromQuery,
+  getCachedByEntity
+} from './cacheService';
 import { getFromIndexedDB, saveToIndexedDB, clearOldIndexedDBEntries } from './indexedDBService';
 import { parseQuery, shouldUseComplexModel } from './queryParser';
 import { getFromTMDB } from './tmdbService';
@@ -162,7 +168,21 @@ export async function fetchMovieData(
       };
     }
 
-    // Check localStorage second
+    // Entity-first localStorage path (query -> entity -> payload).
+    const queryEntity = resolveEntityFromQuery(query, provider);
+    if (queryEntity) {
+      const entityCached = getCachedByEntity(provider, queryEntity.media_type, queryEntity.tmdb_id);
+      if (entityCached) {
+        debugLog('[ai] cache hit from localStorage entity key');
+        saveToIndexedDB(query, provider, entityCached.movieData, entityCached.sources);
+        return {
+          ...entityCached,
+          error: undefined
+        };
+      }
+    }
+
+    // Legacy query-key fallback (with automatic entity backfill in cacheService)
     const cached = getCachedResponse(query, provider);
     if (cached) {
       debugLog('[ai] cache hit from localStorage');

--- a/services/cacheService.ts
+++ b/services/cacheService.ts
@@ -8,7 +8,17 @@ interface CachedResponse {
   provider: string;
 }
 
+interface QueryEntityIndexEntry {
+  tmdb_id: string;
+  media_type: 'movie' | 'tv';
+  timestamp: number;
+  provider: string;
+  query: string;
+}
+
 const CACHE_KEY_PREFIX = 'moviemonk_cache_';
+const CACHE_ENTITY_KEY_PREFIX = `${CACHE_KEY_PREFIX}entity_`;
+const CACHE_QUERY_INDEX_KEY_PREFIX = `${CACHE_KEY_PREFIX}qidx_`;
 const CACHE_DURATION = 6 * 60 * 60 * 1000; // 6 hours (reduced from 24h to prevent stale data)
 
 /**
@@ -19,12 +29,161 @@ function getCacheKey(query: string, provider: string): string {
   return `${CACHE_KEY_PREFIX}${provider}_${normalized}`;
 }
 
+function getQueryIndexKey(query: string, provider: string): string {
+  const normalized = query.toLowerCase().trim();
+  return `${CACHE_QUERY_INDEX_KEY_PREFIX}${provider}_${normalized}`;
+}
+
+function getEntityCacheKey(provider: string, mediaType: 'movie' | 'tv', tmdbId: string): string {
+  return `${CACHE_ENTITY_KEY_PREFIX}${provider}_${mediaType}_${String(tmdbId).trim()}`;
+}
+
+function normalizeMediaTypeFromMovie(movieData: MovieData): 'movie' | 'tv' | null {
+  if (movieData.media_type === 'movie' || movieData.media_type === 'tv') {
+    return movieData.media_type;
+  }
+  if (movieData.type === 'show') return 'tv';
+  if (movieData.type === 'movie') return 'movie';
+  return null;
+}
+
+function getEntityFromMovie(movieData: MovieData): { tmdb_id: string; media_type: 'movie' | 'tv' } | null {
+  const tmdbId = String(movieData.tmdb_id || '').trim();
+  if (!tmdbId) return null;
+
+  const mediaType = normalizeMediaTypeFromMovie(movieData);
+  if (!mediaType) return null;
+
+  return {
+    tmdb_id: tmdbId,
+    media_type: mediaType
+  };
+}
+
+/**
+ * Check if cache entry is still valid
+ */
+function isValidTimestamp(timestamp: number): boolean {
+  const now = Date.now();
+  return Number.isFinite(timestamp) && (now - timestamp) < CACHE_DURATION;
+}
+
 /**
  * Check if cache entry is still valid
  */
 function isValidCache(cached: CachedResponse): boolean {
-  const now = Date.now();
-  return (now - cached.timestamp) < CACHE_DURATION;
+  return isValidTimestamp(cached.timestamp);
+}
+
+/**
+ * Resolve entity tuple from query, when known.
+ */
+export function resolveEntityFromQuery(
+  query: string,
+  provider: string
+): { tmdb_id: string; media_type: 'movie' | 'tv' } | null {
+  try {
+    const key = getQueryIndexKey(query, provider);
+    const raw = localStorage.getItem(key);
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw) as QueryEntityIndexEntry;
+    if (!parsed || !isValidTimestamp(parsed.timestamp)) {
+      localStorage.removeItem(key);
+      return null;
+    }
+
+    if (!parsed.tmdb_id || (parsed.media_type !== 'movie' && parsed.media_type !== 'tv')) {
+      localStorage.removeItem(key);
+      return null;
+    }
+
+    return {
+      tmdb_id: parsed.tmdb_id,
+      media_type: parsed.media_type
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Link a search query to an entity cache key.
+ */
+export function linkQueryToEntity(
+  query: string,
+  provider: string,
+  mediaType: 'movie' | 'tv',
+  tmdbId: string
+): void {
+  try {
+    const key = getQueryIndexKey(query, provider);
+    const payload: QueryEntityIndexEntry = {
+      query: query.toLowerCase().trim(),
+      provider,
+      media_type: mediaType,
+      tmdb_id: String(tmdbId).trim(),
+      timestamp: Date.now()
+    };
+    localStorage.setItem(key, JSON.stringify(payload));
+  } catch {
+    // Best effort only.
+  }
+}
+
+/**
+ * Get cached response by entity key.
+ */
+export function getCachedByEntity(
+  provider: string,
+  mediaType: 'movie' | 'tv',
+  tmdbId: string
+): { movieData: MovieData; sources: GroundingSource[] | null } | null {
+  try {
+    const key = getEntityCacheKey(provider, mediaType, tmdbId);
+    const raw = localStorage.getItem(key);
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw) as CachedResponse;
+    if (!isValidCache(parsed)) {
+      localStorage.removeItem(key);
+      return null;
+    }
+
+    return {
+      movieData: parsed.movieData,
+      sources: parsed.sources
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save response to entity cache.
+ */
+export function setCachedByEntity(
+  provider: string,
+  mediaType: 'movie' | 'tv',
+  tmdbId: string,
+  movieData: MovieData,
+  sources: GroundingSource[] | null,
+  query = ''
+): void {
+  try {
+    const key = getEntityCacheKey(provider, mediaType, tmdbId);
+    const payload: CachedResponse = {
+      movieData,
+      sources,
+      timestamp: Date.now(),
+      query: query.toLowerCase().trim(),
+      provider
+    };
+
+    localStorage.setItem(key, JSON.stringify(payload));
+  } catch {
+    // Best effort only.
+  }
 }
 
 /**
@@ -32,6 +191,17 @@ function isValidCache(cached: CachedResponse): boolean {
  */
 export function getCachedResponse(query: string, provider: string): { movieData: MovieData; sources: GroundingSource[] | null } | null {
   try {
+    // Entity-first path via query->entity index.
+    const resolved = resolveEntityFromQuery(query, provider);
+    if (resolved) {
+      const entityCached = getCachedByEntity(provider, resolved.media_type, resolved.tmdb_id);
+      if (entityCached) {
+        console.log(`[cache] entity hit for "${query}" with ${provider}`);
+        return entityCached;
+      }
+    }
+
+    // Legacy query-key fallback.
     const key = getCacheKey(query, provider);
     const cached = localStorage.getItem(key);
     
@@ -43,6 +213,13 @@ export function getCachedResponse(query: string, provider: string): { movieData:
       // Cache expired, remove it
       localStorage.removeItem(key);
       return null;
+    }
+
+    // Backfill entity cache/index from legacy query cache when possible.
+    const entity = getEntityFromMovie(parsedCache.movieData);
+    if (entity) {
+      setCachedByEntity(provider, entity.media_type, entity.tmdb_id, parsedCache.movieData, parsedCache.sources, query);
+      linkQueryToEntity(query, provider, entity.media_type, entity.tmdb_id);
     }
     
     console.log(`[cache] hit for "${query}" with ${provider}`);
@@ -76,6 +253,14 @@ export function cacheResponse(
     };
     
     localStorage.setItem(key, JSON.stringify(cacheEntry));
+
+    // Write entity cache/index whenever TMDB entity data is present.
+    const entity = getEntityFromMovie(movieData);
+    if (entity) {
+      setCachedByEntity(provider, entity.media_type, entity.tmdb_id, movieData, sources, query);
+      linkQueryToEntity(query, provider, entity.media_type, entity.tmdb_id);
+    }
+
     console.log(`[cache] stored response for "${query}" with ${provider}`);
   } catch (error) {
     console.warn('Cache write error (storage might be full):', error);
@@ -98,8 +283,8 @@ export function clearOldCacheEntries(): void {
         const cached = localStorage.getItem(key);
         if (cached) {
           try {
-            const parsedCache: CachedResponse = JSON.parse(cached);
-            if ((now - parsedCache.timestamp) >= CACHE_DURATION) {
+            const parsedCache = JSON.parse(cached) as { timestamp?: number };
+            if (!Number.isFinite(parsedCache.timestamp) || (now - Number(parsedCache.timestamp)) >= CACHE_DURATION) {
               keysToRemove.push(key);
             }
           } catch (e) {

--- a/services/indexedDBService.ts
+++ b/services/indexedDBService.ts
@@ -11,7 +11,24 @@ interface CachedMovie {
   sources: GroundingSource[] | null;
   timestamp: number;
   provider: string;
+  kind?: 'query' | 'entity';
 }
+
+interface QueryEntityIndexEntry {
+  id: string;
+  query: string;
+  provider: string;
+  tmdb_id: string;
+  media_type: 'movie' | 'tv';
+  timestamp: number;
+  kind: 'qidx';
+}
+
+type CacheRecord = CachedMovie | QueryEntityIndexEntry;
+
+const CACHE_DURATION = 7 * 24 * 60 * 60 * 1000; // 7 days
+const ENTITY_KEY_PREFIX = 'entity_';
+const QUERY_INDEX_KEY_PREFIX = 'qidx_';
 
 /**
  * Initialize IndexedDB
@@ -38,8 +55,158 @@ function openDB(): Promise<IDBDatabase> {
 /**
  * Generate cache key from query
  */
-function generateKey(query: string, provider: string): string {
+function generateQueryKey(query: string, provider: string): string {
   return `${provider}_${query.toLowerCase().trim()}`;
+}
+
+function generateEntityKey(provider: string, mediaType: 'movie' | 'tv', tmdbId: string): string {
+  return `${ENTITY_KEY_PREFIX}${provider}_${mediaType}_${String(tmdbId).trim()}`;
+}
+
+function generateQueryIndexKey(query: string, provider: string): string {
+  return `${QUERY_INDEX_KEY_PREFIX}${provider}_${query.toLowerCase().trim()}`;
+}
+
+function normalizeMediaTypeFromMovie(movieData: MovieData): 'movie' | 'tv' | null {
+  if (movieData.media_type === 'movie' || movieData.media_type === 'tv') {
+    return movieData.media_type;
+  }
+  if (movieData.type === 'show') return 'tv';
+  if (movieData.type === 'movie') return 'movie';
+  return null;
+}
+
+function getEntityFromMovie(movieData: MovieData): { tmdb_id: string; media_type: 'movie' | 'tv' } | null {
+  const tmdbId = String(movieData.tmdb_id || '').trim();
+  if (!tmdbId) return null;
+
+  const mediaType = normalizeMediaTypeFromMovie(movieData);
+  if (!mediaType) return null;
+
+  return {
+    tmdb_id: tmdbId,
+    media_type: mediaType
+  };
+}
+
+function isValidTimestamp(timestamp: number): boolean {
+  return Number.isFinite(timestamp) && (Date.now() - timestamp) < CACHE_DURATION;
+}
+
+export async function resolveEntityFromIndexedDB(
+  query: string,
+  provider: string
+): Promise<{ tmdb_id: string; media_type: 'movie' | 'tv' } | null> {
+  try {
+    const db = await openDB();
+    const transaction = db.transaction(STORE_NAME, 'readwrite');
+    const store = transaction.objectStore(STORE_NAME);
+    const key = generateQueryIndexKey(query, provider);
+
+    return new Promise((resolve, reject) => {
+      const request = store.get(key);
+
+      request.onsuccess = () => {
+        const record = request.result as QueryEntityIndexEntry | undefined;
+        if (!record || record.kind !== 'qidx') {
+          resolve(null);
+          return;
+        }
+
+        if (!isValidTimestamp(record.timestamp)) {
+          store.delete(key);
+          resolve(null);
+          return;
+        }
+
+        if (!record.tmdb_id || (record.media_type !== 'movie' && record.media_type !== 'tv')) {
+          store.delete(key);
+          resolve(null);
+          return;
+        }
+
+        resolve({
+          tmdb_id: record.tmdb_id,
+          media_type: record.media_type
+        });
+      };
+
+      request.onerror = () => reject(request.error);
+    });
+  } catch {
+    return null;
+  }
+}
+
+export async function linkQueryToEntityInIndexedDB(
+  query: string,
+  provider: string,
+  mediaType: 'movie' | 'tv',
+  tmdbId: string
+): Promise<void> {
+  try {
+    const db = await openDB();
+    const transaction = db.transaction(STORE_NAME, 'readwrite');
+    const store = transaction.objectStore(STORE_NAME);
+
+    const payload: QueryEntityIndexEntry = {
+      id: generateQueryIndexKey(query, provider),
+      query: query.toLowerCase().trim(),
+      provider,
+      media_type: mediaType,
+      tmdb_id: String(tmdbId).trim(),
+      timestamp: Date.now(),
+      kind: 'qidx'
+    };
+
+    return new Promise((resolve, reject) => {
+      const request = store.put(payload);
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(request.error);
+    });
+  } catch {
+    // Best effort only.
+  }
+}
+
+export async function getFromIndexedDBByEntity(
+  provider: string,
+  mediaType: 'movie' | 'tv',
+  tmdbId: string
+): Promise<{ movieData: MovieData; sources: GroundingSource[] | null } | null> {
+  try {
+    const db = await openDB();
+    const transaction = db.transaction(STORE_NAME, 'readwrite');
+    const store = transaction.objectStore(STORE_NAME);
+    const key = generateEntityKey(provider, mediaType, tmdbId);
+
+    return new Promise((resolve, reject) => {
+      const request = store.get(key);
+
+      request.onsuccess = () => {
+        const cached = request.result as CachedMovie | undefined;
+        if (!cached) {
+          resolve(null);
+          return;
+        }
+
+        if (!isValidTimestamp(cached.timestamp)) {
+          store.delete(key);
+          resolve(null);
+          return;
+        }
+
+        resolve({
+          movieData: cached.movieData,
+          sources: cached.sources
+        });
+      };
+
+      request.onerror = () => reject(request.error);
+    });
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -50,10 +217,20 @@ export async function getFromIndexedDB(
   provider: string
 ): Promise<{ movieData: MovieData; sources: GroundingSource[] | null } | null> {
   try {
+    // Entity-first path via query->entity index.
+    const entity = await resolveEntityFromIndexedDB(query, provider);
+    if (entity) {
+      const byEntity = await getFromIndexedDBByEntity(provider, entity.media_type, entity.tmdb_id);
+      if (byEntity) {
+        console.log(`[indexeddb] entity hit for "${query}" with ${provider}`);
+        return byEntity;
+      }
+    }
+
     const db = await openDB();
-    const transaction = db.transaction(STORE_NAME, 'readonly');
+    const transaction = db.transaction(STORE_NAME, 'readwrite');
     const store = transaction.objectStore(STORE_NAME);
-    const key = generateKey(query, provider);
+    const key = generateQueryKey(query, provider);
 
     return new Promise((resolve, reject) => {
       const request = store.get(key);
@@ -67,10 +244,7 @@ export async function getFromIndexedDB(
         }
 
         // Check if cache is still valid (7 days - reduced from 30 for accuracy)
-        const age = Date.now() - cached.timestamp;
-        const MAX_AGE = 7 * 24 * 60 * 60 * 1000; // 7 days
-
-        if (age > MAX_AGE) {
+        if (!isValidTimestamp(cached.timestamp)) {
           // Cache expired, delete it
           deleteFromIndexedDB(query, provider);
           resolve(null);
@@ -84,6 +258,12 @@ export async function getFromIndexedDB(
           deleteFromIndexedDB(query, provider);
           resolve(null);
           return;
+        }
+
+        // Backfill entity cache/index from legacy query-key entries when possible.
+        const resolvedEntity = getEntityFromMovie(cached.movieData);
+        if (resolvedEntity) {
+          void saveToIndexedDB(query, provider, cached.movieData, cached.sources);
         }
 
         console.log(`[indexeddb] hit for "${query}" with ${provider}`);
@@ -116,23 +296,42 @@ export async function saveToIndexedDB(
     const store = transaction.objectStore(STORE_NAME);
 
     const cached: CachedMovie = {
-      id: generateKey(query, provider),
+      id: generateQueryKey(query, provider),
       query: query.toLowerCase().trim(),
       movieData,
       sources,
       timestamp: Date.now(),
-      provider
+      provider,
+      kind: 'query'
     };
 
     return new Promise((resolve, reject) => {
-      const request = store.put(cached);
+      const primaryWrite = store.put(cached);
 
-      request.onsuccess = () => {
-        console.log(`[indexeddb] saved "${query}" with ${provider}`);
-        resolve();
+      primaryWrite.onsuccess = () => {
+        const entity = getEntityFromMovie(movieData);
+        if (!entity) {
+          console.log(`[indexeddb] saved "${query}" with ${provider}`);
+          resolve();
+          return;
+        }
+
+        const entityRecord: CachedMovie = {
+          ...cached,
+          id: generateEntityKey(provider, entity.media_type, entity.tmdb_id),
+          kind: 'entity'
+        };
+
+        const entityWrite = store.put(entityRecord);
+        entityWrite.onsuccess = () => {
+          void linkQueryToEntityInIndexedDB(query, provider, entity.media_type, entity.tmdb_id);
+          console.log(`[indexeddb] saved "${query}" with ${provider}`);
+          resolve();
+        };
+        entityWrite.onerror = () => reject(entityWrite.error);
       };
 
-      request.onerror = () => reject(request.error);
+      primaryWrite.onerror = () => reject(primaryWrite.error);
     });
   } catch (error) {
     console.warn('IndexedDB write error:', error);
@@ -147,7 +346,7 @@ export async function deleteFromIndexedDB(query: string, provider: string): Prom
     const db = await openDB();
     const transaction = db.transaction(STORE_NAME, 'readwrite');
     const store = transaction.objectStore(STORE_NAME);
-    const key = generateKey(query, provider);
+    const key = generateQueryKey(query, provider);
 
     return new Promise((resolve, reject) => {
       const request = store.delete(key);
@@ -169,8 +368,7 @@ export async function clearOldIndexedDBEntries(): Promise<void> {
     const store = transaction.objectStore(STORE_NAME);
     const index = store.index('timestamp');
 
-    const MAX_AGE = 7 * 24 * 60 * 60 * 1000; // 7 days
-    const cutoff = Date.now() - MAX_AGE;
+    const cutoff = Date.now() - CACHE_DURATION;
 
     return new Promise((resolve, reject) => {
       const request = index.openCursor();
@@ -180,7 +378,8 @@ export async function clearOldIndexedDBEntries(): Promise<void> {
         const cursor = (event.target as IDBRequest<IDBCursorWithValue>).result;
 
         if (cursor) {
-          if (cursor.value.timestamp < cutoff) {
+          const value = cursor.value as { timestamp?: number };
+          if (!Number.isFinite(value.timestamp) || Number(value.timestamp) < cutoff) {
             cursor.delete();
             deletedCount++;
           }
@@ -212,7 +411,14 @@ export async function getAllCachedMovies(): Promise<CachedMovie[]> {
     return new Promise((resolve, reject) => {
       const request = store.getAll();
 
-      request.onsuccess = () => resolve(request.result || []);
+      request.onsuccess = () => {
+        const all = (request.result || []) as CacheRecord[];
+        const onlyMovieRecords = all.filter((record): record is CachedMovie => {
+          const maybe = record as CachedMovie;
+          return Boolean(maybe.movieData && maybe.sources !== undefined);
+        });
+        resolve(onlyMovieRecords);
+      };
       request.onerror = () => reject(request.error);
     });
   } catch (error) {


### PR DESCRIPTION
This pull request introduces a new "entity-first" caching mechanism for movie and TV data, improving cache hit rates and consistency across different queries that refer to the same entity. The caching logic now maps queries to entity keys (based on TMDB ID and media type) and stores/retrieves cache entries by these entity keys, both in `localStorage` and `IndexedDB`. The changes also ensure that legacy query-key caches are backfilled into the new entity-indexed structure, and comprehensive tests have been added for these behaviors.

**Entity-First Caching Implementation**

- Added functions to map queries to entity keys (`tmdb_id` and `media_type`), and to store and retrieve cached responses by entity in both `localStorage` and `IndexedDB`. This allows different queries referring to the same movie or show to share a single cache entry, improving cache efficiency and consistency. [[1]](diffhunk://#diff-51befabc2654f220e0fd28b9d4a92aa2b877dde384c714664f2af30bb7b2b3eeR32-R204) [[2]](diffhunk://#diff-51befabc2654f220e0fd28b9d4a92aa2b877dde384c714664f2af30bb7b2b3eeR218-R224) [[3]](diffhunk://#diff-51befabc2654f220e0fd28b9d4a92aa2b877dde384c714664f2af30bb7b2b3eeR256-R263) [[4]](diffhunk://#diff-80ccdd13ee6a5c73e9823e32877455594eef83d177c392e838f34e58df199aeaR14-R32) [[5]](diffhunk://#diff-80ccdd13ee6a5c73e9823e32877455594eef83d177c392e838f34e58df199aeaL41-R211) [[6]](diffhunk://#diff-80ccdd13ee6a5c73e9823e32877455594eef83d177c392e838f34e58df199aeaR220-R233) [[7]](diffhunk://#diff-80ccdd13ee6a5c73e9823e32877455594eef83d177c392e838f34e58df199aeaL119-R334)

- The `fetchMovieData` function in `aiService.ts` now attempts to resolve a query to its entity and fetch the cache by entity key first, before falling back to the legacy query-key cache. [[1]](diffhunk://#diff-3929ca61720846d12b44dc26aa9f15f4175c5cb47ae67d26820dfb749610cbe5L4-R10) [[2]](diffhunk://#diff-3929ca61720846d12b44dc26aa9f15f4175c5cb47ae67d26820dfb749610cbe5L165-R185)

**Cache Backfilling and Expiry Improvements**

- When a legacy query-key cache is accessed, the system backfills the corresponding entity cache and query-to-entity mapping, ensuring a smooth migration to the new caching strategy. [[1]](diffhunk://#diff-51befabc2654f220e0fd28b9d4a92aa2b877dde384c714664f2af30bb7b2b3eeR218-R224) [[2]](diffhunk://#diff-80ccdd13ee6a5c73e9823e32877455594eef83d177c392e838f34e58df199aeaR263-R268)

- Improved cache expiry logic and timestamp validation to prevent stale data from being served, and to clean up expired entries more reliably. [[1]](diffhunk://#diff-51befabc2654f220e0fd28b9d4a92aa2b877dde384c714664f2af30bb7b2b3eeL101-R287) [[2]](diffhunk://#diff-80ccdd13ee6a5c73e9823e32877455594eef83d177c392e838f34e58df199aeaL70-R247)

**Testing Enhancements**

- Added comprehensive tests for the new entity-first caching logic, including mapping queries to entities, storing and retrieving by entity, and backfilling from legacy caches.

**Mocking Updates for Tests**

- Updated mocks in integration tests to support the new entity-based cache functions.