### PR TITLE
security: fix CodeQL security alerts

### DIFF
--- a/__tests__/lib/seo.test.ts
+++ b/__tests__/lib/seo.test.ts
@@ -24,6 +24,8 @@ describe('safeImgUrl', () => {
     expect(safeImgUrl('https://static.tvmaze.com/uploads/images/medium_portrait/1/3.jpg')).toBe('https://static.tvmaze.com/uploads/images/medium_portrait/1/3.jpg');
     expect(safeImgUrl('https://images.unsplash.com/photo-123456')).toBe('https://images.unsplash.com/photo-123456');
     expect(safeImgUrl('https://lh3.googleusercontent.com/a/ACg8ocL3')).toBe('https://lh3.googleusercontent.com/a/ACg8ocL3');
+    expect(safeImgUrl('https://sub.lh3.googleusercontent.com/a/ACg8ocL3')).toBe('https://sub.lh3.googleusercontent.com/a/ACg8ocL3');
+    expect(safeImgUrl('https://foo.googleusercontent.com/avatar')).toBe('https://foo.googleusercontent.com/avatar');
     expect(safeImgUrl('https://avatars.githubusercontent.com/u/9919')).toBe('https://avatars.githubusercontent.com/u/9919');
     expect(safeImgUrl('https://projectref.supabase.co/storage/v1/object/public/avatars/avatar.jpg')).toBe('https://projectref.supabase.co/storage/v1/object/public/avatars/avatar.jpg');
     expect(safeImgUrl('https://moviemonk-ai.vercel.app/logo.png')).toBe('https://moviemonk-ai.vercel.app/logo.png');

--- a/__tests__/lib/seo.test.ts
+++ b/__tests__/lib/seo.test.ts
@@ -1,0 +1,44 @@
+import { safeImgUrl } from '../../lib/seo';
+
+describe('safeImgUrl', () => {
+  it('should allow safe relative paths and reject protocol-relative paths', () => {
+    expect(safeImgUrl('/assets/poster.jpg')).toBe('/assets/poster.jpg');
+    expect(safeImgUrl('/nested/path/image.png')).toBe('/nested/path/image.png');
+    expect(safeImgUrl('//evil.com/poster.jpg')).toBe('');
+  });
+
+  it('should allow valid data:image base64 URLs and reject other data: protocols', () => {
+    const validDataUrl = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+    expect(safeImgUrl(validDataUrl)).toBe(validDataUrl);
+    expect(safeImgUrl('data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==')).toBe('');
+  });
+
+  it('should reject dangerous protocols like javascript:', () => {
+    expect(safeImgUrl('javascript:alert(1)')).toBe('');
+    expect(safeImgUrl('javascript://alert(1)')).toBe('');
+    expect(safeImgUrl('vbscript:msgbox(1)')).toBe('');
+  });
+
+  it('should allow whitelisted external domains', () => {
+    expect(safeImgUrl('https://image.tmdb.org/t/p/w500/abc.jpg')).toBe('https://image.tmdb.org/t/p/w500/abc.jpg');
+    expect(safeImgUrl('https://static.tvmaze.com/uploads/images/medium_portrait/1/3.jpg')).toBe('https://static.tvmaze.com/uploads/images/medium_portrait/1/3.jpg');
+    expect(safeImgUrl('https://images.unsplash.com/photo-123456')).toBe('https://images.unsplash.com/photo-123456');
+    expect(safeImgUrl('https://lh3.googleusercontent.com/a/ACg8ocL3')).toBe('https://lh3.googleusercontent.com/a/ACg8ocL3');
+    expect(safeImgUrl('https://avatars.githubusercontent.com/u/9919')).toBe('https://avatars.githubusercontent.com/u/9919');
+    expect(safeImgUrl('https://projectref.supabase.co/storage/v1/object/public/avatars/avatar.jpg')).toBe('https://projectref.supabase.co/storage/v1/object/public/avatars/avatar.jpg');
+    expect(safeImgUrl('https://moviemonk-ai.vercel.app/logo.png')).toBe('https://moviemonk-ai.vercel.app/logo.png');
+    expect(safeImgUrl('http://localhost:3000/avatar.png')).toBe('http://localhost:3000/avatar.png');
+  });
+
+  it('should reject non-whitelisted external domains', () => {
+    expect(safeImgUrl('https://evil.com/avatar.png')).toBe('');
+    expect(safeImgUrl('https://attacker.com/image.tmdb.org/avatar.png')).toBe('');
+    expect(safeImgUrl('https://image.tmdb.org.evil.com/avatar.png')).toBe('');
+  });
+
+  it('should return fallback for null, undefined, or empty values', () => {
+    expect(safeImgUrl(null, 'fallback.png')).toBe('fallback.png');
+    expect(safeImgUrl(undefined, 'fallback.png')).toBe('fallback.png');
+    expect(safeImgUrl('', 'fallback.png')).toBe('fallback.png');
+  });
+});

--- a/components/DynamicSearchIsland.tsx
+++ b/components/DynamicSearchIsland.tsx
@@ -22,13 +22,7 @@ import { apiGet } from '../lib/apiClient';
 import { safeImgUrl } from '../lib/seo';
 import '../styles/dynamic-search-island.css';
 
-const SAFE_URL_PATTERN = /^(?:https?:\/\/(?:image\.tmdb\.org|static\.tvmaze\.com|images\.unsplash\.com|(?:[a-zA-Z0-9-]+\.)*googleusercontent\.com|graph\.facebook\.com|avatars\.githubusercontent\.com|moviemonk-ai\.vercel.app|(?:[a-zA-Z0-9-]+\.)*supabase\.co)\/|\/(?!\/))/i;
-const SAFE_DATA_URL_PATTERN = /^data:image\/(?:jpeg|png|webp|gif|svg\+xml);base64,[a-zA-Z0-9+/=]+$/i;
-const SAFE_LOCAL_URL_PATTERN = /^https?:\/\/localhost(?::\d+)?\//i;
 
-const IS_DEV = typeof process !== 'undefined'
-  ? (process.env?.NODE_ENV === 'development' || process.env?.NODE_ENV === 'test')
-  : (typeof window !== 'undefined' && (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'));
 
 // Helper to get icon component by suggestion type
 const getSuggestionIconComponent = (type: string, media_type?: string) => {
@@ -783,18 +777,8 @@ const DynamicSearchIsland: React.FC<DynamicSearchIslandProps> = ({ initialQuery,
               )}
               {!isTrendingLoading && dailyTrending.map((suggestion) => {
                 const IconComponent = getSuggestionIconComponent(suggestion.type, suggestion.media_type);
-                const bannerUrl = safeImgUrl(suggestion.banner_url);
-                const posterUrl = safeImgUrl(suggestion.poster_url);
-                const displayBanner = typeof bannerUrl === 'string' && (
-                  SAFE_URL_PATTERN.test(bannerUrl) || 
-                  SAFE_DATA_URL_PATTERN.test(bannerUrl) ||
-                  (IS_DEV && SAFE_LOCAL_URL_PATTERN.test(bannerUrl))
-                ) ? bannerUrl : '';
-                const displayPoster = typeof posterUrl === 'string' && (
-                  SAFE_URL_PATTERN.test(posterUrl) || 
-                  SAFE_DATA_URL_PATTERN.test(posterUrl) ||
-                  (IS_DEV && SAFE_LOCAL_URL_PATTERN.test(posterUrl))
-                ) ? posterUrl : '';
+                const displayBanner = safeImgUrl(suggestion.banner_url);
+                const displayPoster = safeImgUrl(suggestion.poster_url);
 
                 return (
                   <button
@@ -849,12 +833,7 @@ const DynamicSearchIsland: React.FC<DynamicSearchIslandProps> = ({ initialQuery,
                       known_for_titles: suggestion.known_for_titles
                     })
                   : null;
-                const cleanPoster = safeImgUrl(suggestion.poster_url);
-                const displayPoster = typeof cleanPoster === 'string' && (
-                  SAFE_URL_PATTERN.test(cleanPoster) || 
-                  SAFE_DATA_URL_PATTERN.test(cleanPoster) ||
-                  (IS_DEV && SAFE_LOCAL_URL_PATTERN.test(cleanPoster))
-                ) ? cleanPoster : '';
+                const displayPoster = safeImgUrl(suggestion.poster_url);
 
                 return (
                   <button

--- a/components/DynamicSearchIsland.tsx
+++ b/components/DynamicSearchIsland.tsx
@@ -775,6 +775,19 @@ const DynamicSearchIsland: React.FC<DynamicSearchIslandProps> = ({ initialQuery,
               )}
               {!isTrendingLoading && dailyTrending.map((suggestion) => {
                 const IconComponent = getSuggestionIconComponent(suggestion.type, suggestion.media_type);
+                const bannerUrl = safeImgUrl(suggestion.banner_url);
+                const posterUrl = safeImgUrl(suggestion.poster_url);
+                const displayBanner = (bannerUrl.startsWith('/') && !bannerUrl.startsWith('//')) ||
+                  bannerUrl.startsWith('https://image.tmdb.org/') ||
+                  bannerUrl.startsWith('https://static.tvmaze.com/') ||
+                  bannerUrl.startsWith('https://images.unsplash.com/') ||
+                  bannerUrl.startsWith('data:image/') ? bannerUrl : '';
+                const displayPoster = (posterUrl.startsWith('/') && !posterUrl.startsWith('//')) ||
+                  posterUrl.startsWith('https://image.tmdb.org/') ||
+                  posterUrl.startsWith('https://static.tvmaze.com/') ||
+                  posterUrl.startsWith('https://images.unsplash.com/') ||
+                  posterUrl.startsWith('data:image/') ? posterUrl : '';
+
                 return (
                   <button
                     type="button"
@@ -785,9 +798,9 @@ const DynamicSearchIsland: React.FC<DynamicSearchIslandProps> = ({ initialQuery,
                   >
                     <div className="suggest-poster-wrap is-title">
                       {suggestion.banner_url ? (
-                        <img src={safeImgUrl(suggestion.banner_url)} alt={suggestion.title} className="suggest-poster" loading="lazy" />
+                        <img src={displayBanner} alt={suggestion.title} className="suggest-poster" loading="lazy" />
                       ) : suggestion.poster_url ? (
-                        <img src={safeImgUrl(suggestion.poster_url)} alt={suggestion.title} className="suggest-poster" loading="lazy" />
+                        <img src={displayPoster} alt={suggestion.title} className="suggest-poster" loading="lazy" />
                       ) : (
                         <div className="suggest-poster placeholder">
                           <IconComponent size={24} className="poster-icon" />

--- a/components/DynamicSearchIsland.tsx
+++ b/components/DynamicSearchIsland.tsx
@@ -19,7 +19,7 @@ import { getNextHighlightIndex } from '../services/suggestInteraction';
 import { buildPersonCardPresentation } from '../services/personPresentation';
 import { useDebounce } from '../hooks/useDebounce';
 import { apiGet } from '../lib/apiClient';
-import { safeImgUrl } from '../lib/seo';
+import { safeImgUrl, SAFE_URL_PATTERN, SAFE_DATA_URL_PATTERN, SAFE_LOCAL_URL_PATTERN, IS_DEV } from '../lib/seo';
 import '../styles/dynamic-search-island.css';
 
 
@@ -780,6 +780,18 @@ const DynamicSearchIsland: React.FC<DynamicSearchIslandProps> = ({ initialQuery,
                 const displayBanner = safeImgUrl(suggestion.banner_url);
                 const displayPoster = safeImgUrl(suggestion.poster_url);
 
+                const safeBanner = displayBanner && (
+                  SAFE_URL_PATTERN.test(displayBanner) ||
+                  SAFE_DATA_URL_PATTERN.test(displayBanner) ||
+                  (IS_DEV && SAFE_LOCAL_URL_PATTERN.test(displayBanner))
+                ) ? displayBanner : '';
+
+                const safePoster = displayPoster && (
+                  SAFE_URL_PATTERN.test(displayPoster) ||
+                  SAFE_DATA_URL_PATTERN.test(displayPoster) ||
+                  (IS_DEV && SAFE_LOCAL_URL_PATTERN.test(displayPoster))
+                ) ? displayPoster : '';
+
                 return (
                   <button
                     type="button"
@@ -789,10 +801,10 @@ const DynamicSearchIsland: React.FC<DynamicSearchIslandProps> = ({ initialQuery,
                     onClick={() => handleSuggestionSelect(suggestion)}
                   >
                     <div className="suggest-poster-wrap is-title">
-                      {displayBanner ? (
-                        <img src={displayBanner} alt={suggestion.title} className="suggest-poster" loading="lazy" />
-                      ) : displayPoster ? (
-                        <img src={displayPoster} alt={suggestion.title} className="suggest-poster" loading="lazy" />
+                      {safeBanner ? (
+                        <img src={safeBanner} alt={suggestion.title} className="suggest-poster" loading="lazy" />
+                      ) : safePoster ? (
+                        <img src={safePoster} alt={suggestion.title} className="suggest-poster" loading="lazy" />
                       ) : (
                         <div className="suggest-poster placeholder">
                           <IconComponent size={24} className="poster-icon" />
@@ -835,6 +847,12 @@ const DynamicSearchIsland: React.FC<DynamicSearchIslandProps> = ({ initialQuery,
                   : null;
                 const displayPoster = safeImgUrl(suggestion.poster_url);
 
+                const safePoster = displayPoster && (
+                  SAFE_URL_PATTERN.test(displayPoster) ||
+                  SAFE_DATA_URL_PATTERN.test(displayPoster) ||
+                  (IS_DEV && SAFE_LOCAL_URL_PATTERN.test(displayPoster))
+                ) ? displayPoster : '';
+
                 return (
                   <button
                     type="button"
@@ -848,8 +866,8 @@ const DynamicSearchIsland: React.FC<DynamicSearchIslandProps> = ({ initialQuery,
                   >
                     {/* Poster */}
                     <div className={`suggest-poster-wrap ${suggestion.type === 'person' ? 'is-person' : 'is-title'}`}>
-                      {displayPoster ? (
-                        <img src={displayPoster} alt={suggestion.title} className="suggest-poster" loading="lazy" />
+                      {safePoster ? (
+                        <img src={safePoster} alt={suggestion.title} className="suggest-poster" loading="lazy" />
                       ) : (
                         <div className="suggest-poster placeholder">
                           <IconComponent size={24} className="poster-icon" />

--- a/components/DynamicSearchIsland.tsx
+++ b/components/DynamicSearchIsland.tsx
@@ -19,6 +19,7 @@ import { getNextHighlightIndex } from '../services/suggestInteraction';
 import { buildPersonCardPresentation } from '../services/personPresentation';
 import { useDebounce } from '../hooks/useDebounce';
 import { apiGet } from '../lib/apiClient';
+import { safeImgUrl } from '../lib/seo';
 import '../styles/dynamic-search-island.css';
 
 // Helper to get icon component by suggestion type
@@ -784,9 +785,9 @@ const DynamicSearchIsland: React.FC<DynamicSearchIslandProps> = ({ initialQuery,
                   >
                     <div className="suggest-poster-wrap is-title">
                       {suggestion.banner_url ? (
-                        <img src={suggestion.banner_url} alt={suggestion.title} className="suggest-poster" loading="lazy" />
+                        <img src={safeImgUrl(suggestion.banner_url)} alt={suggestion.title} className="suggest-poster" loading="lazy" />
                       ) : suggestion.poster_url ? (
-                        <img src={suggestion.poster_url} alt={suggestion.title} className="suggest-poster" loading="lazy" />
+                        <img src={safeImgUrl(suggestion.poster_url)} alt={suggestion.title} className="suggest-poster" loading="lazy" />
                       ) : (
                         <div className="suggest-poster placeholder">
                           <IconComponent size={24} className="poster-icon" />

--- a/components/DynamicSearchIsland.tsx
+++ b/components/DynamicSearchIsland.tsx
@@ -22,6 +22,14 @@ import { apiGet } from '../lib/apiClient';
 import { safeImgUrl } from '../lib/seo';
 import '../styles/dynamic-search-island.css';
 
+const SAFE_URL_PATTERN = /^(?:https?:\/\/(?:image\.tmdb\.org|static\.tvmaze\.com|images\.unsplash\.com|(?:[a-zA-Z0-9-]+\.)*googleusercontent\.com|graph\.facebook\.com|avatars\.githubusercontent\.com|moviemonk-ai\.vercel.app|(?:[a-zA-Z0-9-]+\.)*supabase\.co)\/|\/(?!\/))/i;
+const SAFE_DATA_URL_PATTERN = /^data:image\/(?:jpeg|png|webp|gif|svg\+xml);base64,[a-zA-Z0-9+/=]+$/i;
+const SAFE_LOCAL_URL_PATTERN = /^https?:\/\/localhost(?::\d+)?\//i;
+
+const IS_DEV = typeof process !== 'undefined'
+  ? (process.env?.NODE_ENV === 'development' || process.env?.NODE_ENV === 'test')
+  : (typeof window !== 'undefined' && (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'));
+
 // Helper to get icon component by suggestion type
 const getSuggestionIconComponent = (type: string, media_type?: string) => {
   if (type === 'movie' || media_type === 'movie') return Film;
@@ -777,16 +785,16 @@ const DynamicSearchIsland: React.FC<DynamicSearchIslandProps> = ({ initialQuery,
                 const IconComponent = getSuggestionIconComponent(suggestion.type, suggestion.media_type);
                 const bannerUrl = safeImgUrl(suggestion.banner_url);
                 const posterUrl = safeImgUrl(suggestion.poster_url);
-                const displayBanner = (bannerUrl.startsWith('/') && !bannerUrl.startsWith('//')) ||
-                  bannerUrl.startsWith('https://image.tmdb.org/') ||
-                  bannerUrl.startsWith('https://static.tvmaze.com/') ||
-                  bannerUrl.startsWith('https://images.unsplash.com/') ||
-                  bannerUrl.startsWith('data:image/') ? bannerUrl : '';
-                const displayPoster = (posterUrl.startsWith('/') && !posterUrl.startsWith('//')) ||
-                  posterUrl.startsWith('https://image.tmdb.org/') ||
-                  posterUrl.startsWith('https://static.tvmaze.com/') ||
-                  posterUrl.startsWith('https://images.unsplash.com/') ||
-                  posterUrl.startsWith('data:image/') ? posterUrl : '';
+                const displayBanner = typeof bannerUrl === 'string' && (
+                  SAFE_URL_PATTERN.test(bannerUrl) || 
+                  SAFE_DATA_URL_PATTERN.test(bannerUrl) ||
+                  (IS_DEV && SAFE_LOCAL_URL_PATTERN.test(bannerUrl))
+                ) ? bannerUrl : '';
+                const displayPoster = typeof posterUrl === 'string' && (
+                  SAFE_URL_PATTERN.test(posterUrl) || 
+                  SAFE_DATA_URL_PATTERN.test(posterUrl) ||
+                  (IS_DEV && SAFE_LOCAL_URL_PATTERN.test(posterUrl))
+                ) ? posterUrl : '';
 
                 return (
                   <button
@@ -842,11 +850,11 @@ const DynamicSearchIsland: React.FC<DynamicSearchIslandProps> = ({ initialQuery,
                     })
                   : null;
                 const cleanPoster = safeImgUrl(suggestion.poster_url);
-                const displayPoster = (cleanPoster.startsWith('/') && !cleanPoster.startsWith('//')) ||
-                  cleanPoster.startsWith('https://image.tmdb.org/') ||
-                  cleanPoster.startsWith('https://static.tvmaze.com/') ||
-                  cleanPoster.startsWith('https://images.unsplash.com/') ||
-                  cleanPoster.startsWith('data:image/') ? cleanPoster : '';
+                const displayPoster = typeof cleanPoster === 'string' && (
+                  SAFE_URL_PATTERN.test(cleanPoster) || 
+                  SAFE_DATA_URL_PATTERN.test(cleanPoster) ||
+                  (IS_DEV && SAFE_LOCAL_URL_PATTERN.test(cleanPoster))
+                ) ? cleanPoster : '';
 
                 return (
                   <button

--- a/components/DynamicSearchIsland.tsx
+++ b/components/DynamicSearchIsland.tsx
@@ -797,9 +797,9 @@ const DynamicSearchIsland: React.FC<DynamicSearchIslandProps> = ({ initialQuery,
                     onClick={() => handleSuggestionSelect(suggestion)}
                   >
                     <div className="suggest-poster-wrap is-title">
-                      {suggestion.banner_url ? (
+                      {displayBanner ? (
                         <img src={displayBanner} alt={suggestion.title} className="suggest-poster" loading="lazy" />
-                      ) : suggestion.poster_url ? (
+                      ) : displayPoster ? (
                         <img src={displayPoster} alt={suggestion.title} className="suggest-poster" loading="lazy" />
                       ) : (
                         <div className="suggest-poster placeholder">
@@ -841,6 +841,13 @@ const DynamicSearchIsland: React.FC<DynamicSearchIslandProps> = ({ initialQuery,
                       known_for_titles: suggestion.known_for_titles
                     })
                   : null;
+                const cleanPoster = safeImgUrl(suggestion.poster_url);
+                const displayPoster = (cleanPoster.startsWith('/') && !cleanPoster.startsWith('//')) ||
+                  cleanPoster.startsWith('https://image.tmdb.org/') ||
+                  cleanPoster.startsWith('https://static.tvmaze.com/') ||
+                  cleanPoster.startsWith('https://images.unsplash.com/') ||
+                  cleanPoster.startsWith('data:image/') ? cleanPoster : '';
+
                 return (
                   <button
                     type="button"
@@ -854,8 +861,8 @@ const DynamicSearchIsland: React.FC<DynamicSearchIslandProps> = ({ initialQuery,
                   >
                     {/* Poster */}
                     <div className={`suggest-poster-wrap ${suggestion.type === 'person' ? 'is-person' : 'is-title'}`}>
-                      {suggestion.poster_url ? (
-                        <img src={suggestion.poster_url} alt={suggestion.title} className="suggest-poster" loading="lazy" />
+                      {displayPoster ? (
+                        <img src={displayPoster} alt={suggestion.title} className="suggest-poster" loading="lazy" />
                       ) : (
                         <div className="suggest-poster placeholder">
                           <IconComponent size={24} className="poster-icon" />

--- a/components/TVShowDisplay.tsx
+++ b/components/TVShowDisplay.tsx
@@ -473,7 +473,7 @@ const TVShowDisplay: React.FC<TVShowDisplayProps> = ({ movie, isWatched = false,
 
                                         {expandedEpisode === episode.id && episode.summary && (
                                             <div className="episode-summary-enhanced">
-                                                <p>{episode.summary.replace(/<[^>]*>/g, '')}</p>
+                                                <p>{stripHtmlTags(episode.summary)}</p>
                                             </div>
                                         )}
                                     </div>

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -175,9 +175,39 @@ export function safeImgUrl(url: string | null | undefined, fallback = ''): strin
   if (!url) return fallback;
   const trimmed = url.trim();
   
-  // Allow only http, https, relative paths, or base64 data images
-  if (/^(https?:\/\/|\/|data:image\/)/i.test(trimmed)) {
+  // 1. Safe relative URLs (must start with / but not //)
+  if (trimmed.startsWith('/') && !trimmed.startsWith('//')) {
     return trimmed;
+  }
+  
+  // 2. Safe inline data images
+  if (trimmed.startsWith('data:image/')) {
+    return trimmed;
+  }
+  
+  // 3. Absolute URLs: validate protocol and restrict to safe whitelisted hostnames
+  if (/^https?:\/\//i.test(trimmed)) {
+    try {
+      const parsed = new URL(trimmed);
+      const host = parsed.hostname.toLowerCase();
+      const isWhitelisted =
+        host === 'image.tmdb.org' ||
+        host === 'static.tvmaze.com' ||
+        host === 'images.unsplash.com' ||
+        host === 'lh3.googleusercontent.com' ||
+        host.endsWith('.googleusercontent.com') ||
+        host === 'graph.facebook.com' ||
+        host === 'avatars.githubusercontent.com' ||
+        host.endsWith('.supabase.co') ||
+        host === 'moviemonk-ai.vercel.app' ||
+        host === 'localhost';
+
+      if (isWhitelisted) {
+        return trimmed;
+      }
+    } catch {
+      // Return fallback on malformed URL parsing
+    }
   }
   
   return fallback;

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -184,16 +184,49 @@ export function safeImgUrl(url: string | null | undefined, fallback = ''): strin
   if (!url) return fallback;
   const trimmed = url.trim();
   
-  if (SAFE_URL_PATTERN.test(trimmed)) {
+  // 1. Allow single-root relative paths (e.g., /assets/logo.png), but block protocol-relative ones (e.g. //evil.com)
+  if (trimmed.startsWith('/') && !trimmed.startsWith('//')) {
     return trimmed;
   }
   
-  if (IS_DEV && SAFE_LOCAL_URL_PATTERN.test(trimmed)) {
-    return trimmed;
+  // 2. Allow safe data URI patterns (base64 images only)
+  if (trimmed.startsWith('data:image/')) {
+    if (SAFE_DATA_URL_PATTERN.test(trimmed)) {
+      return trimmed;
+    }
+    return fallback;
   }
   
-  if (SAFE_DATA_URL_PATTERN.test(trimmed)) {
-    return trimmed;
+  // 3. For absolute URLs, parse and validate host and protocol
+  try {
+    const parsed = new URL(trimmed);
+    const protocol = parsed.protocol.toLowerCase();
+    
+    // Prevent javascript: or other non-http schemes
+    if (protocol !== 'http:' && protocol !== 'https:') {
+      return fallback;
+    }
+    
+    const host = parsed.hostname.toLowerCase();
+    
+    // Check if host matches allowed patterns
+    const isAllowedHost = 
+      host === 'image.tmdb.org' ||
+      host === 'static.tvmaze.com' ||
+      host === 'images.unsplash.com' ||
+      host === 'graph.facebook.com' ||
+      host === 'avatars.githubusercontent.com' ||
+      host === 'moviemonk-ai.vercel.app' ||
+      host === 'googleusercontent.com' ||
+      host.endsWith('.googleusercontent.com') ||
+      host.endsWith('.supabase.co') ||
+      (IS_DEV && (host === 'localhost' || host === '127.0.0.1'));
+      
+    if (isAllowedHost) {
+      return trimmed;
+    }
+  } catch (e) {
+    // Parsing failed, not a valid absolute URL
   }
   
   return fallback;

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -174,11 +174,11 @@ export function buildPersonJsonLd(data: SeoPersonPayload): Record<string, unknow
 export const SAFE_URL_PATTERN = /^(?:https?:\/\/(?:image\.tmdb\.org|static\.tvmaze\.com|images\.unsplash\.com|(?:[a-zA-Z0-9-]+\.)*googleusercontent\.com|graph\.facebook\.com|avatars\.githubusercontent\.com|moviemonk-ai\.vercel.app|(?:[a-zA-Z0-9-]+\.)*supabase\.co)\/|\/(?!\/))/i;
 export const SAFE_DATA_URL_PATTERN = /^data:image\/(?:jpeg|png|webp|gif|svg\+xml);base64,[a-zA-Z0-9+/=]+$/i;
 
-const IS_DEV = typeof process !== 'undefined'
+export const IS_DEV = typeof process !== 'undefined'
   ? (process.env?.NODE_ENV === 'development' || process.env?.NODE_ENV === 'test')
   : (typeof window !== 'undefined' && (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'));
 
-const SAFE_LOCAL_URL_PATTERN = /^https?:\/\/localhost(?::\d+)?\//i;
+export const SAFE_LOCAL_URL_PATTERN = /^https?:\/\/localhost(?::\d+)?\//i;
 
 export function safeImgUrl(url: string | null | undefined, fallback = ''): string {
   if (!url) return fallback;

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -176,38 +176,21 @@ export function safeImgUrl(url: string | null | undefined, fallback = ''): strin
   const trimmed = url.trim();
   
   // 1. Safe relative URLs (must start with / but not //)
-  if (trimmed.startsWith('/') && !trimmed.startsWith('//')) {
+  // We use a regex match starting with / to satisfy CodeQL's path sanitizer detection
+  if (/^\/[^/]/ .test(trimmed)) {
     return trimmed;
   }
   
   // 2. Safe inline data images
-  if (trimmed.startsWith('data:image/')) {
+  // We use a regex match starting with data:image/ to satisfy CodeQL's data URL sanitizer detection
+  if (/^data:image\/(?:jpeg|png|webp|gif|svg\+xml);base64,[a-zA-Z0-9+/=]+$/i.test(trimmed)) {
     return trimmed;
   }
   
   // 3. Absolute URLs: validate protocol and restrict to safe whitelisted hostnames
-  if (/^https?:\/\//i.test(trimmed)) {
-    try {
-      const parsed = new URL(trimmed);
-      const host = parsed.hostname.toLowerCase();
-      const isWhitelisted =
-        host === 'image.tmdb.org' ||
-        host === 'static.tvmaze.com' ||
-        host === 'images.unsplash.com' ||
-        host === 'lh3.googleusercontent.com' ||
-        host.endsWith('.googleusercontent.com') ||
-        host === 'graph.facebook.com' ||
-        host === 'avatars.githubusercontent.com' ||
-        host.endsWith('.supabase.co') ||
-        host === 'moviemonk-ai.vercel.app' ||
-        host === 'localhost';
-
-      if (isWhitelisted) {
-        return trimmed;
-      }
-    } catch {
-      // Return fallback on malformed URL parsing
-    }
+  // We use an explicit regex matching the whitelisted domains to satisfy CodeQL's hostname sanitizer detection
+  if (/^https?:\/\/(?:image\.tmdb\.org|static\.tvmaze\.com|images\.unsplash\.com|lh3\.googleusercontent\.com|[a-z0-9.-]+\.googleusercontent\.com|graph\.facebook\.com|avatars\.githubusercontent\.com|[a-z0-9.-]+\.supabase\.co|moviemonk-ai\.vercel\.app|localhost(?::\d+)?)(?:\/|$)/i.test(trimmed)) {
+    return trimmed;
   }
   
   return fallback;

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -176,22 +176,39 @@ export function safeImgUrl(url: string | null | undefined, fallback = ''): strin
   const trimmed = url.trim();
   
   // 1. Safe relative URLs (must start with / but not //)
-  // We use a regex match starting with / to satisfy CodeQL's path sanitizer detection
-  if (/^\/[^/]/ .test(trimmed)) {
+  if (trimmed.startsWith('/') && !trimmed.startsWith('//')) {
     return trimmed;
   }
   
   // 2. Safe inline data images
-  // We use a regex match starting with data:image/ to satisfy CodeQL's data URL sanitizer detection
-  if (/^data:image\/(?:jpeg|png|webp|gif|svg\+xml);base64,[a-zA-Z0-9+/=]+$/i.test(trimmed)) {
-    return trimmed;
+  if (trimmed.startsWith('data:image/')) {
+    if (/^data:image\/(?:jpeg|png|webp|gif|svg\+xml);base64,[a-zA-Z0-9+/=]+$/i.test(trimmed)) {
+      return trimmed;
+    }
   }
   
-  // 3. Absolute URLs: validate protocol and restrict to safe whitelisted hostnames
-  // We use an explicit regex matching the whitelisted domains to satisfy CodeQL's hostname sanitizer detection
-  if (/^https?:\/\/(?:image\.tmdb\.org|static\.tvmaze\.com|images\.unsplash\.com|lh3\.googleusercontent\.com|[a-z0-9.-]+\.googleusercontent\.com|graph\.facebook\.com|avatars\.githubusercontent\.com|[a-z0-9.-]+\.supabase\.co|moviemonk-ai\.vercel\.app|localhost(?::\d+)?)(?:\/|$)/i.test(trimmed)) {
-    return trimmed;
-  }
+  // 3. Absolute URLs: validate using URL constructor and exact hostname matches
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      const host = parsed.hostname.toLowerCase();
+      const isAllowedHost = 
+        host === 'image.tmdb.org' ||
+        host === 'static.tvmaze.com' ||
+        host === 'images.unsplash.com' ||
+        host === 'lh3.googleusercontent.com' ||
+        host === 'graph.facebook.com' ||
+        host === 'avatars.githubusercontent.com' ||
+        host === 'moviemonk-ai.vercel.app' ||
+        host === 'localhost' ||
+        host.endsWith('.googleusercontent.com') ||
+        host.endsWith('.supabase.co');
+        
+      if (isAllowedHost) {
+        return trimmed;
+      }
+    }
+  } catch {}
   
   return fallback;
 }

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -171,44 +171,30 @@ export function buildPersonJsonLd(data: SeoPersonPayload): Record<string, unknow
  * Sanitizes an image URL to prevent XSS (e.g. javascript: URLs)
  * and client-side unvalidated URL redirection by allowing only safe protocols.
  */
+export const SAFE_URL_PATTERN = /^(?:https?:\/\/(?:image\.tmdb\.org|static\.tvmaze\.com|images\.unsplash\.com|(?:[a-zA-Z0-9-]+\.)*googleusercontent\.com|graph\.facebook\.com|avatars\.githubusercontent\.com|moviemonk-ai\.vercel.app|(?:[a-zA-Z0-9-]+\.)*supabase\.co)\/|\/(?!\/))/i;
+export const SAFE_DATA_URL_PATTERN = /^data:image\/(?:jpeg|png|webp|gif|svg\+xml);base64,[a-zA-Z0-9+/=]+$/i;
+
+const IS_DEV = typeof process !== 'undefined'
+  ? (process.env?.NODE_ENV === 'development' || process.env?.NODE_ENV === 'test')
+  : (typeof window !== 'undefined' && (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'));
+
+const SAFE_LOCAL_URL_PATTERN = /^https?:\/\/localhost(?::\d+)?\//i;
+
 export function safeImgUrl(url: string | null | undefined, fallback = ''): string {
   if (!url) return fallback;
   const trimmed = url.trim();
   
-  // 1. Safe relative URLs (must start with / but not //)
-  if (trimmed.startsWith('/') && !trimmed.startsWith('//')) {
+  if (SAFE_URL_PATTERN.test(trimmed)) {
     return trimmed;
   }
   
-  // 2. Safe inline data images
-  if (trimmed.startsWith('data:image/')) {
-    if (/^data:image\/(?:jpeg|png|webp|gif|svg\+xml);base64,[a-zA-Z0-9+/=]+$/i.test(trimmed)) {
-      return trimmed;
-    }
+  if (IS_DEV && SAFE_LOCAL_URL_PATTERN.test(trimmed)) {
+    return trimmed;
   }
   
-  // 3. Absolute URLs: validate using URL constructor and exact hostname matches
-  try {
-    const parsed = new URL(trimmed);
-    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
-      const host = parsed.hostname.toLowerCase();
-      const isAllowedHost = 
-        host === 'image.tmdb.org' ||
-        host === 'static.tvmaze.com' ||
-        host === 'images.unsplash.com' ||
-        host === 'lh3.googleusercontent.com' ||
-        host === 'graph.facebook.com' ||
-        host === 'avatars.githubusercontent.com' ||
-        host === 'moviemonk-ai.vercel.app' ||
-        host === 'localhost' ||
-        host.endsWith('.googleusercontent.com') ||
-        host.endsWith('.supabase.co');
-        
-      if (isAllowedHost) {
-        return trimmed;
-      }
-    }
-  } catch {}
+  if (SAFE_DATA_URL_PATTERN.test(trimmed)) {
+    return trimmed;
+  }
   
   return fallback;
 }

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -166,3 +166,20 @@ export function buildPersonJsonLd(data: SeoPersonPayload): Record<string, unknow
     notableWork: notableWork.length > 0 ? notableWork : undefined
   };
 }
+
+/**
+ * Sanitizes an image URL to prevent XSS (e.g. javascript: URLs)
+ * and client-side unvalidated URL redirection by allowing only safe protocols.
+ */
+export function safeImgUrl(url: string | null | undefined, fallback = ''): string {
+  if (!url) return fallback;
+  const trimmed = url.trim();
+  
+  // Allow only http, https, relative paths, or base64 data images
+  if (/^(https?:\/\/|\/|data:image\/)/i.test(trimmed)) {
+    return trimmed;
+  }
+  
+  return fallback;
+}
+

--- a/pages/SettingsPages.tsx
+++ b/pages/SettingsPages.tsx
@@ -212,16 +212,32 @@ function Avatar({ user, profile, size }: { user: any; profile?: UserProfileSetti
   }, [url]);
 
   const cleanUrl = safeImgUrl(url);
-  const displayUrl = (cleanUrl.startsWith('/') && !cleanUrl.startsWith('//')) ||
-    cleanUrl.startsWith('https://lh3.googleusercontent.com/') ||
-    cleanUrl.startsWith('https://graph.facebook.com/') ||
-    cleanUrl.startsWith('https://avatars.githubusercontent.com/') ||
-    cleanUrl.startsWith('https://moviemonk-ai.vercel.app/') ||
-    cleanUrl.startsWith('http://localhost:') ||
-    cleanUrl.startsWith('data:image/') ||
-    (cleanUrl.startsWith('https://') && cleanUrl.includes('.supabase.co/'))
-    ? cleanUrl
-    : '';
+  let isSafe = false;
+  if (cleanUrl) {
+    if (cleanUrl.startsWith('/') && !cleanUrl.startsWith('//')) {
+      isSafe = true;
+    } else if (cleanUrl.startsWith('data:image/')) {
+      isSafe = true;
+    } else {
+      try {
+        const parsed = new URL(cleanUrl);
+        const host = parsed.hostname.toLowerCase();
+        if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+          isSafe = [
+            'image.tmdb.org',
+            'static.tvmaze.com',
+            'images.unsplash.com',
+            'lh3.googleusercontent.com',
+            'graph.facebook.com',
+            'avatars.githubusercontent.com',
+            'moviemonk-ai.vercel.app',
+            'localhost'
+          ].includes(host) || host.endsWith('.supabase.co');
+        }
+      } catch {}
+    }
+  }
+  const displayUrl = isSafe ? cleanUrl : '';
 
   if (displayUrl && !imageFailed) {
     return (

--- a/pages/SettingsPages.tsx
+++ b/pages/SettingsPages.tsx
@@ -23,7 +23,7 @@ import {
   upsertProfileSettings
 } from '../services/userSettingsService';
 import { getAuthAvatarUrl, getAuthDisplayName, getAuthProviderLabel } from '../lib/authIdentity';
-import { safeImgUrl } from '../lib/seo';
+import { safeImgUrl, SAFE_URL_PATTERN, SAFE_DATA_URL_PATTERN, SAFE_LOCAL_URL_PATTERN, IS_DEV } from '../lib/seo';
 
 /* ────────────────────────────────────────────
    Constants
@@ -213,11 +213,17 @@ function Avatar({ user, profile, size }: { user: any; profile?: UserProfileSetti
 
   const displayUrl = safeImgUrl(url);
 
-  if (displayUrl && !imageFailed) {
+  const safeUrl = displayUrl && (
+    SAFE_URL_PATTERN.test(displayUrl) ||
+    SAFE_DATA_URL_PATTERN.test(displayUrl) ||
+    (IS_DEV && SAFE_LOCAL_URL_PATTERN.test(displayUrl))
+  ) ? displayUrl : '';
+
+  if (safeUrl && !imageFailed) {
     return (
       <div className={cls} style={{ padding: 0, overflow: 'hidden' }}>
         <img
-          src={displayUrl}
+          src={safeUrl}
           alt=""
           onError={() => setImageFailed(true)}
           style={{ width: '100%', height: '100%', objectFit: 'cover', borderRadius: '50%' }}

--- a/pages/SettingsPages.tsx
+++ b/pages/SettingsPages.tsx
@@ -200,6 +200,14 @@ function getInitial(name?: string, email?: string): string {
   return '?';
 }
 
+const SAFE_URL_PATTERN = /^(?:https?:\/\/(?:image\.tmdb\.org|static\.tvmaze\.com|images\.unsplash\.com|(?:[a-zA-Z0-9-]+\.)*googleusercontent\.com|graph\.facebook\.com|avatars\.githubusercontent\.com|moviemonk-ai\.vercel.app|(?:[a-zA-Z0-9-]+\.)*supabase\.co)\/|\/(?!\/))/i;
+const SAFE_DATA_URL_PATTERN = /^data:image\/(?:jpeg|png|webp|gif|svg\+xml);base64,[a-zA-Z0-9+/=]+$/i;
+const SAFE_LOCAL_URL_PATTERN = /^https?:\/\/localhost(?::\d+)?\//i;
+
+const IS_DEV = typeof process !== 'undefined'
+  ? (process.env?.NODE_ENV === 'development' || process.env?.NODE_ENV === 'test')
+  : (typeof window !== 'undefined' && (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'));
+
 function Avatar({ user, profile, size }: { user: any; profile?: UserProfileSettings; size?: 'lg' }) {
   const url = getAuthAvatarUrl(user, profile?.avatarUrl);
   const name = getAuthDisplayName(user, profile?.fullName);
@@ -212,31 +220,11 @@ function Avatar({ user, profile, size }: { user: any; profile?: UserProfileSetti
   }, [url]);
 
   const cleanUrl = safeImgUrl(url);
-  let isSafe = false;
-  if (cleanUrl) {
-    if (cleanUrl.startsWith('/') && !cleanUrl.startsWith('//')) {
-      isSafe = true;
-    } else if (cleanUrl.startsWith('data:image/')) {
-      isSafe = true;
-    } else {
-      try {
-        const parsed = new URL(cleanUrl);
-        const host = parsed.hostname.toLowerCase();
-        if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
-          isSafe = [
-            'image.tmdb.org',
-            'static.tvmaze.com',
-            'images.unsplash.com',
-            'lh3.googleusercontent.com',
-            'graph.facebook.com',
-            'avatars.githubusercontent.com',
-            'moviemonk-ai.vercel.app',
-            'localhost'
-          ].includes(host) || host.endsWith('.supabase.co');
-        }
-      } catch {}
-    }
-  }
+  const isSafe = typeof cleanUrl === 'string' && (
+    SAFE_URL_PATTERN.test(cleanUrl) || 
+    SAFE_DATA_URL_PATTERN.test(cleanUrl) ||
+    (IS_DEV && SAFE_LOCAL_URL_PATTERN.test(cleanUrl))
+  );
   const displayUrl = isSafe ? cleanUrl : '';
 
   if (displayUrl && !imageFailed) {

--- a/pages/SettingsPages.tsx
+++ b/pages/SettingsPages.tsx
@@ -211,11 +211,23 @@ function Avatar({ user, profile, size }: { user: any; profile?: UserProfileSetti
     setImageFailed(false);
   }, [url]);
 
-  if (url && !imageFailed) {
+  const cleanUrl = safeImgUrl(url);
+  const displayUrl = (cleanUrl.startsWith('/') && !cleanUrl.startsWith('//')) ||
+    cleanUrl.startsWith('https://lh3.googleusercontent.com/') ||
+    cleanUrl.startsWith('https://graph.facebook.com/') ||
+    cleanUrl.startsWith('https://avatars.githubusercontent.com/') ||
+    cleanUrl.startsWith('https://moviemonk-ai.vercel.app/') ||
+    cleanUrl.startsWith('http://localhost:') ||
+    cleanUrl.startsWith('data:image/') ||
+    (cleanUrl.startsWith('https://') && cleanUrl.includes('.supabase.co/'))
+    ? cleanUrl
+    : '';
+
+  if (displayUrl && !imageFailed) {
     return (
       <div className={cls} style={{ padding: 0, overflow: 'hidden' }}>
         <img
-          src={safeImgUrl(url)}
+          src={displayUrl}
           alt=""
           onError={() => setImageFailed(true)}
           style={{ width: '100%', height: '100%', objectFit: 'cover', borderRadius: '50%' }}

--- a/pages/SettingsPages.tsx
+++ b/pages/SettingsPages.tsx
@@ -23,6 +23,7 @@ import {
   upsertProfileSettings
 } from '../services/userSettingsService';
 import { getAuthAvatarUrl, getAuthDisplayName, getAuthProviderLabel } from '../lib/authIdentity';
+import { safeImgUrl } from '../lib/seo';
 
 /* ────────────────────────────────────────────
    Constants
@@ -214,7 +215,7 @@ function Avatar({ user, profile, size }: { user: any; profile?: UserProfileSetti
     return (
       <div className={cls} style={{ padding: 0, overflow: 'hidden' }}>
         <img
-          src={url}
+          src={safeImgUrl(url)}
           alt=""
           onError={() => setImageFailed(true)}
           style={{ width: '100%', height: '100%', objectFit: 'cover', borderRadius: '50%' }}

--- a/pages/SettingsPages.tsx
+++ b/pages/SettingsPages.tsx
@@ -200,14 +200,6 @@ function getInitial(name?: string, email?: string): string {
   return '?';
 }
 
-const SAFE_URL_PATTERN = /^(?:https?:\/\/(?:image\.tmdb\.org|static\.tvmaze\.com|images\.unsplash\.com|(?:[a-zA-Z0-9-]+\.)*googleusercontent\.com|graph\.facebook\.com|avatars\.githubusercontent\.com|moviemonk-ai\.vercel.app|(?:[a-zA-Z0-9-]+\.)*supabase\.co)\/|\/(?!\/))/i;
-const SAFE_DATA_URL_PATTERN = /^data:image\/(?:jpeg|png|webp|gif|svg\+xml);base64,[a-zA-Z0-9+/=]+$/i;
-const SAFE_LOCAL_URL_PATTERN = /^https?:\/\/localhost(?::\d+)?\//i;
-
-const IS_DEV = typeof process !== 'undefined'
-  ? (process.env?.NODE_ENV === 'development' || process.env?.NODE_ENV === 'test')
-  : (typeof window !== 'undefined' && (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'));
-
 function Avatar({ user, profile, size }: { user: any; profile?: UserProfileSettings; size?: 'lg' }) {
   const url = getAuthAvatarUrl(user, profile?.avatarUrl);
   const name = getAuthDisplayName(user, profile?.fullName);
@@ -219,13 +211,7 @@ function Avatar({ user, profile, size }: { user: any; profile?: UserProfileSetti
     setImageFailed(false);
   }, [url]);
 
-  const cleanUrl = safeImgUrl(url);
-  const isSafe = typeof cleanUrl === 'string' && (
-    SAFE_URL_PATTERN.test(cleanUrl) || 
-    SAFE_DATA_URL_PATTERN.test(cleanUrl) ||
-    (IS_DEV && SAFE_LOCAL_URL_PATTERN.test(cleanUrl))
-  );
-  const displayUrl = isSafe ? cleanUrl : '';
+  const displayUrl = safeImgUrl(url);
 
   if (displayUrl && !imageFailed) {
     return (

--- a/pages/WatchlistsDashboard.tsx
+++ b/pages/WatchlistsDashboard.tsx
@@ -25,7 +25,7 @@ import { getAuthAvatarUrl, getAuthDisplayName } from '../lib/authIdentity';
 // } from '../services/watchlistReminders';
 import { emitClientEvent } from '../services/clientObservability';
 import { apiPost } from '../lib/apiClient';
-import { safeImgUrl } from '../lib/seo';
+import { safeImgUrl, SAFE_URL_PATTERN, SAFE_DATA_URL_PATTERN, SAFE_LOCAL_URL_PATTERN, IS_DEV } from '../lib/seo';
 
 
 

--- a/pages/WatchlistsDashboard.tsx
+++ b/pages/WatchlistsDashboard.tsx
@@ -25,6 +25,7 @@ import { getAuthAvatarUrl, getAuthDisplayName } from '../lib/authIdentity';
 // } from '../services/watchlistReminders';
 import { emitClientEvent } from '../services/clientObservability';
 import { apiPost } from '../lib/apiClient';
+import { safeImgUrl } from '../lib/seo';
 
 function DashboardLayout({ children }: { children: React.ReactNode }) {
   const navigate = useNavigate();
@@ -502,7 +503,7 @@ export function WatchlistsDashboard() {
         <div className="flex items-center gap-4 sm:gap-6 relative z-10">
           <div className="w-14 h-14 sm:w-20 sm:h-20 rounded-full border border-white/10 overflow-hidden flex-shrink-0 bg-brand-surface shadow-xl transition-transform hover:scale-105 duration-300">
             {avatarUrl && !avatarFailed ? (
-              <img src={avatarUrl} alt="Avatar" className="w-full h-full object-cover" onError={() => setAvatarFailed(true)} />
+              <img src={safeImgUrl(avatarUrl)} alt="Avatar" className="w-full h-full object-cover" onError={() => setAvatarFailed(true)} />
             ) : (
               <div className="w-full h-full flex items-center justify-center text-white text-xl sm:text-2xl font-bold bg-gradient-to-br from-brand-primary to-brand-secondary">
                 {displayName[0]?.toUpperCase() || '?'}
@@ -700,7 +701,7 @@ export function WatchlistsDashboard() {
                   <Link to={`/${item.media_type}/${item.tmdb_id}`} className="absolute inset-0 z-10" />
                   {/* Poster */}
                   {item.poster_url ? (
-                    <img src={item.poster_url} alt={item.title} className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105" loading="lazy" />
+                    <img src={safeImgUrl(item.poster_url)} alt={item.title} className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105" loading="lazy" />
                   ) : (
                     <div className="w-full h-full flex items-center justify-center p-4 text-center text-brand-text-dark bg-gradient-to-br from-brand-surface to-black/40 text-sm">
                       {item.title}
@@ -838,7 +839,7 @@ export function WatchlistsDashboard() {
                     >
                       <Link to={`/${item.movie.type === 'show' ? 'tv' : 'movie'}/${item.movie.tmdb_id}`} className="absolute inset-0 z-10" />
                       {item.movie.poster_url ? (
-                        <img src={item.movie.poster_url} alt={item.movie.title} className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105" loading="lazy" />
+                        <img src={safeImgUrl(item.movie.poster_url)} alt={item.movie.title} className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105" loading="lazy" />
                       ) : (
                         <div className="w-full h-full flex items-center justify-center p-4 text-center text-brand-text-dark bg-gradient-to-br from-brand-surface to-black/40">
                           {item.movie.title}

--- a/pages/WatchlistsDashboard.tsx
+++ b/pages/WatchlistsDashboard.tsx
@@ -493,16 +493,32 @@ export function WatchlistsDashboard() {
   }
 
   const cleanAvatarUrl = safeImgUrl(avatarUrl);
-  const displayAvatarUrl = (cleanAvatarUrl.startsWith('/') && !cleanAvatarUrl.startsWith('//')) ||
-    cleanAvatarUrl.startsWith('https://lh3.googleusercontent.com/') ||
-    cleanAvatarUrl.startsWith('https://graph.facebook.com/') ||
-    cleanAvatarUrl.startsWith('https://avatars.githubusercontent.com/') ||
-    cleanAvatarUrl.startsWith('https://moviemonk-ai.vercel.app/') ||
-    cleanAvatarUrl.startsWith('http://localhost:') ||
-    cleanAvatarUrl.startsWith('data:image/') ||
-    (cleanAvatarUrl.startsWith('https://') && cleanAvatarUrl.includes('.supabase.co/'))
-    ? cleanAvatarUrl
-    : '';
+  let isAvatarSafe = false;
+  if (cleanAvatarUrl) {
+    if (cleanAvatarUrl.startsWith('/') && !cleanAvatarUrl.startsWith('//')) {
+      isAvatarSafe = true;
+    } else if (cleanAvatarUrl.startsWith('data:image/')) {
+      isAvatarSafe = true;
+    } else {
+      try {
+        const parsed = new URL(cleanAvatarUrl);
+        const host = parsed.hostname.toLowerCase();
+        if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+          isAvatarSafe = [
+            'image.tmdb.org',
+            'static.tvmaze.com',
+            'images.unsplash.com',
+            'lh3.googleusercontent.com',
+            'graph.facebook.com',
+            'avatars.githubusercontent.com',
+            'moviemonk-ai.vercel.app',
+            'localhost'
+          ].includes(host) || host.endsWith('.supabase.co');
+        }
+      } catch {}
+    }
+  }
+  const displayAvatarUrl = isAvatarSafe ? cleanAvatarUrl : '';
 
   return (
     <DashboardLayout>
@@ -514,7 +530,7 @@ export function WatchlistsDashboard() {
 
         <div className="flex items-center gap-4 sm:gap-6 relative z-10">
           <div className="w-14 h-14 sm:w-20 sm:h-20 rounded-full border border-white/10 overflow-hidden flex-shrink-0 bg-brand-surface shadow-xl transition-transform hover:scale-105 duration-300">
-            {avatarUrl && !avatarFailed ? (
+            {displayAvatarUrl && !avatarFailed ? (
               <img src={displayAvatarUrl} alt="Avatar" className="w-full h-full object-cover" onError={() => setAvatarFailed(true)} />
             ) : (
               <div className="w-full h-full flex items-center justify-center text-white text-xl sm:text-2xl font-bold bg-gradient-to-br from-brand-primary to-brand-secondary">
@@ -720,7 +736,7 @@ export function WatchlistsDashboard() {
                   <div key={`${item.tmdb_id}-${item.media_type}`} className="group relative aspect-[2/3] rounded-xl overflow-hidden glass-panel border border-white/5 select-none bg-brand-surface shadow-xl hover:ring-2 hover:ring-emerald-500/50 transition-all cursor-pointer">
                     <Link to={`/${item.media_type}/${item.tmdb_id}`} className="absolute inset-0 z-10" />
                     {/* Poster */}
-                    {item.poster_url ? (
+                    {displayPosterUrl ? (
                       <img src={displayPosterUrl} alt={item.title} className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105" loading="lazy" />
                     ) : (
                       <div className="w-full h-full flex items-center justify-center p-4 text-center text-brand-text-dark bg-gradient-to-br from-brand-surface to-black/40 text-sm">
@@ -866,7 +882,7 @@ export function WatchlistsDashboard() {
                       }}
                     >
                       <Link to={`/${item.movie.type === 'show' ? 'tv' : 'movie'}/${item.movie.tmdb_id}`} className="absolute inset-0 z-10" />
-                      {item.movie.poster_url ? (
+                      {displayPosterUrl ? (
                         <img src={displayPosterUrl} alt={item.movie.title} className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105" loading="lazy" />
                       ) : (
                         <div className="w-full h-full flex items-center justify-center p-4 text-center text-brand-text-dark bg-gradient-to-br from-brand-surface to-black/40">

--- a/pages/WatchlistsDashboard.tsx
+++ b/pages/WatchlistsDashboard.tsx
@@ -492,6 +492,18 @@ export function WatchlistsDashboard() {
     );
   }
 
+  const cleanAvatarUrl = safeImgUrl(avatarUrl);
+  const displayAvatarUrl = (cleanAvatarUrl.startsWith('/') && !cleanAvatarUrl.startsWith('//')) ||
+    cleanAvatarUrl.startsWith('https://lh3.googleusercontent.com/') ||
+    cleanAvatarUrl.startsWith('https://graph.facebook.com/') ||
+    cleanAvatarUrl.startsWith('https://avatars.githubusercontent.com/') ||
+    cleanAvatarUrl.startsWith('https://moviemonk-ai.vercel.app/') ||
+    cleanAvatarUrl.startsWith('http://localhost:') ||
+    cleanAvatarUrl.startsWith('data:image/') ||
+    (cleanAvatarUrl.startsWith('https://') && cleanAvatarUrl.includes('.supabase.co/'))
+    ? cleanAvatarUrl
+    : '';
+
   return (
     <DashboardLayout>
       {/* 1. User Header */}
@@ -503,7 +515,7 @@ export function WatchlistsDashboard() {
         <div className="flex items-center gap-4 sm:gap-6 relative z-10">
           <div className="w-14 h-14 sm:w-20 sm:h-20 rounded-full border border-white/10 overflow-hidden flex-shrink-0 bg-brand-surface shadow-xl transition-transform hover:scale-105 duration-300">
             {avatarUrl && !avatarFailed ? (
-              <img src={safeImgUrl(avatarUrl)} alt="Avatar" className="w-full h-full object-cover" onError={() => setAvatarFailed(true)} />
+              <img src={displayAvatarUrl} alt="Avatar" className="w-full h-full object-cover" onError={() => setAvatarFailed(true)} />
             ) : (
               <div className="w-full h-full flex items-center justify-center text-white text-xl sm:text-2xl font-bold bg-gradient-to-br from-brand-primary to-brand-secondary">
                 {displayName[0]?.toUpperCase() || '?'}
@@ -696,46 +708,55 @@ export function WatchlistsDashboard() {
             </div>
           ) : (
             <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 sm:gap-6">
-              {watched.map((item) => (
-                <div key={`${item.tmdb_id}-${item.media_type}`} className="group relative aspect-[2/3] rounded-xl overflow-hidden glass-panel border border-white/5 select-none bg-brand-surface shadow-xl hover:ring-2 hover:ring-emerald-500/50 transition-all cursor-pointer">
-                  <Link to={`/${item.media_type}/${item.tmdb_id}`} className="absolute inset-0 z-10" />
-                  {/* Poster */}
-                  {item.poster_url ? (
-                    <img src={safeImgUrl(item.poster_url)} alt={item.title} className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105" loading="lazy" />
-                  ) : (
-                    <div className="w-full h-full flex items-center justify-center p-4 text-center text-brand-text-dark bg-gradient-to-br from-brand-surface to-black/40 text-sm">
-                      {item.title}
+              {watched.map((item) => {
+                const cleanPosterUrl = safeImgUrl(item.poster_url);
+                const displayPosterUrl = (cleanPosterUrl.startsWith('/') && !cleanPosterUrl.startsWith('//')) ||
+                  cleanPosterUrl.startsWith('https://image.tmdb.org/') ||
+                  cleanPosterUrl.startsWith('https://static.tvmaze.com/') ||
+                  cleanPosterUrl.startsWith('https://images.unsplash.com/') ||
+                  cleanPosterUrl.startsWith('data:image/') ? cleanPosterUrl : '';
+
+                return (
+                  <div key={`${item.tmdb_id}-${item.media_type}`} className="group relative aspect-[2/3] rounded-xl overflow-hidden glass-panel border border-white/5 select-none bg-brand-surface shadow-xl hover:ring-2 hover:ring-emerald-500/50 transition-all cursor-pointer">
+                    <Link to={`/${item.media_type}/${item.tmdb_id}`} className="absolute inset-0 z-10" />
+                    {/* Poster */}
+                    {item.poster_url ? (
+                      <img src={displayPosterUrl} alt={item.title} className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105" loading="lazy" />
+                    ) : (
+                      <div className="w-full h-full flex items-center justify-center p-4 text-center text-brand-text-dark bg-gradient-to-br from-brand-surface to-black/40 text-sm">
+                        {item.title}
+                      </div>
+                    )}
+
+                    {/* Gradient info bar */}
+                    <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/95 via-black/60 to-transparent p-3 pt-12 z-20 pointer-events-none">
+                      <h4 className="text-white font-semibold text-sm line-clamp-2 drop-shadow-md">{item.title}</h4>
+                      <span className="text-xs text-brand-text-light block mt-0.5">{item.year || 'Unknown'}</span>
                     </div>
-                  )}
 
-                  {/* Gradient info bar */}
-                  <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/95 via-black/60 to-transparent p-3 pt-12 z-20 pointer-events-none">
-                    <h4 className="text-white font-semibold text-sm line-clamp-2 drop-shadow-md">{item.title}</h4>
-                    <span className="text-xs text-brand-text-light block mt-0.5">{item.year || 'Unknown'}</span>
+                    {/* Watched badge */}
+                    <div className="absolute top-2 left-2 z-20 px-2 py-0.5 rounded-md bg-emerald-500/80 backdrop-blur-md text-white text-[10px] font-bold tracking-wider uppercase flex items-center gap-1">
+                      <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24"><path fillRule="evenodd" d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12zm13.36-1.814a.75.75 0 10-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 00-1.06 1.06l2.25 2.25a.75.75 0 001.14-.094l3.75-5.25z" clipRule="evenodd" /></svg>
+                      {item.media_type === 'tv' ? 'Series' : 'Movie'}
+                    </div>
+
+                    {/* Unwatch button */}
+                    <button
+                      onClick={() => toggleWatched({
+                        tmdb_id: item.tmdb_id,
+                        media_type: item.media_type,
+                        title: item.title,
+                        poster_url: item.poster_url,
+                        year: item.year,
+                      })}
+                      className="absolute top-2 right-2 z-30 p-2 rounded-full bg-black/60 backdrop-blur-md text-emerald-400 opacity-0 group-hover:opacity-100 transition-all hover:bg-red-500/80 hover:text-white"
+                      title="Remove from watched"
+                    >
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
+                    </button>
                   </div>
-
-                  {/* Watched badge */}
-                  <div className="absolute top-2 left-2 z-20 px-2 py-0.5 rounded-md bg-emerald-500/80 backdrop-blur-md text-white text-[10px] font-bold tracking-wider uppercase flex items-center gap-1">
-                    <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24"><path fillRule="evenodd" d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12zm13.36-1.814a.75.75 0 10-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 00-1.06 1.06l2.25 2.25a.75.75 0 001.14-.094l3.75-5.25z" clipRule="evenodd" /></svg>
-                    {item.media_type === 'tv' ? 'Series' : 'Movie'}
-                  </div>
-
-                  {/* Unwatch button */}
-                  <button
-                    onClick={() => toggleWatched({
-                      tmdb_id: item.tmdb_id,
-                      media_type: item.media_type,
-                      title: item.title,
-                      poster_url: item.poster_url,
-                      year: item.year,
-                    })}
-                    className="absolute top-2 right-2 z-30 p-2 rounded-full bg-black/60 backdrop-blur-md text-emerald-400 opacity-0 group-hover:opacity-100 transition-all hover:bg-red-500/80 hover:text-white"
-                    title="Remove from watched"
-                  >
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
-                  </button>
-                </div>
-              ))}
+                );
+              })}
             </div>
           )}
         </div>
@@ -811,6 +832,13 @@ export function WatchlistsDashboard() {
               <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 sm:gap-6">
                 {activeFolder.items.map(item => {
                   const isWatched = watched.some((w) => w.tmdb_id === String(item.movie.tmdb_id || '') && w.media_type === (item.movie.type === 'show' ? 'tv' : 'movie'));
+                  const cleanPosterUrl = safeImgUrl(item.movie.poster_url);
+                  const displayPosterUrl = (cleanPosterUrl.startsWith('/') && !cleanPosterUrl.startsWith('//')) ||
+                    cleanPosterUrl.startsWith('https://image.tmdb.org/') ||
+                    cleanPosterUrl.startsWith('https://static.tvmaze.com/') ||
+                    cleanPosterUrl.startsWith('https://images.unsplash.com/') ||
+                    cleanPosterUrl.startsWith('data:image/') ? cleanPosterUrl : '';
+
                   return (
                     <div
                       key={item.id}
@@ -839,7 +867,7 @@ export function WatchlistsDashboard() {
                     >
                       <Link to={`/${item.movie.type === 'show' ? 'tv' : 'movie'}/${item.movie.tmdb_id}`} className="absolute inset-0 z-10" />
                       {item.movie.poster_url ? (
-                        <img src={safeImgUrl(item.movie.poster_url)} alt={item.movie.title} className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105" loading="lazy" />
+                        <img src={displayPosterUrl} alt={item.movie.title} className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105" loading="lazy" />
                       ) : (
                         <div className="w-full h-full flex items-center justify-center p-4 text-center text-brand-text-dark bg-gradient-to-br from-brand-surface to-black/40">
                           {item.movie.title}
@@ -919,7 +947,14 @@ export function WatchlistsDashboard() {
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
               {folders.map((folder, index) => {
                 const heroItem = folder.items[0];
-                const topPosters = folder.items.slice(0, 3).map(item => item.movie?.poster_url).filter(Boolean) as string[];
+                const topPosters = folder.items.slice(0, 3).map(item => {
+                  const cleanPoster = safeImgUrl(item.movie?.poster_url);
+                  return (cleanPoster.startsWith('/') && !cleanPoster.startsWith('//')) ||
+                    cleanPoster.startsWith('https://image.tmdb.org/') ||
+                    cleanPoster.startsWith('https://static.tvmaze.com/') ||
+                    cleanPoster.startsWith('https://images.unsplash.com/') ||
+                    cleanPoster.startsWith('data:image/') ? cleanPoster : '';
+                }).filter(Boolean) as string[];
                 return (
                   <div
                     key={folder.id}

--- a/pages/WatchlistsDashboard.tsx
+++ b/pages/WatchlistsDashboard.tsx
@@ -27,13 +27,7 @@ import { emitClientEvent } from '../services/clientObservability';
 import { apiPost } from '../lib/apiClient';
 import { safeImgUrl } from '../lib/seo';
 
-const SAFE_URL_PATTERN = /^(?:https?:\/\/(?:image\.tmdb\.org|static\.tvmaze\.com|images\.unsplash\.com|(?:[a-zA-Z0-9-]+\.)*googleusercontent\.com|graph\.facebook\.com|avatars\.githubusercontent\.com|moviemonk-ai\.vercel.app|(?:[a-zA-Z0-9-]+\.)*supabase\.co)\/|\/(?!\/))/i;
-const SAFE_DATA_URL_PATTERN = /^data:image\/(?:jpeg|png|webp|gif|svg\+xml);base64,[a-zA-Z0-9+/=]+$/i;
-const SAFE_LOCAL_URL_PATTERN = /^https?:\/\/localhost(?::\d+)?\//i;
 
-const IS_DEV = typeof process !== 'undefined'
-  ? (process.env?.NODE_ENV === 'development' || process.env?.NODE_ENV === 'test')
-  : (typeof window !== 'undefined' && (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'));
 
 function DashboardLayout({ children }: { children: React.ReactNode }) {
   const navigate = useNavigate();
@@ -500,13 +494,7 @@ export function WatchlistsDashboard() {
     );
   }
 
-  const cleanAvatarUrl = safeImgUrl(avatarUrl);
-  const isAvatarSafe = typeof cleanAvatarUrl === 'string' && (
-    SAFE_URL_PATTERN.test(cleanAvatarUrl) || 
-    SAFE_DATA_URL_PATTERN.test(cleanAvatarUrl) ||
-    (IS_DEV && SAFE_LOCAL_URL_PATTERN.test(cleanAvatarUrl))
-  );
-  const displayAvatarUrl = isAvatarSafe ? cleanAvatarUrl : '';
+  const displayAvatarUrl = safeImgUrl(avatarUrl);
 
   return (
     <DashboardLayout>
@@ -713,12 +701,7 @@ export function WatchlistsDashboard() {
           ) : (
             <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 sm:gap-6">
               {watched.map((item) => {
-                const cleanPosterUrl = safeImgUrl(item.poster_url);
-                const displayPosterUrl = typeof cleanPosterUrl === 'string' && (
-                  SAFE_URL_PATTERN.test(cleanPosterUrl) || 
-                  SAFE_DATA_URL_PATTERN.test(cleanPosterUrl) ||
-                  (IS_DEV && SAFE_LOCAL_URL_PATTERN.test(cleanPosterUrl))
-                ) ? cleanPosterUrl : '';
+                const displayPosterUrl = safeImgUrl(item.poster_url);
 
                 return (
                   <div key={`${item.tmdb_id}-${item.media_type}`} className="group relative aspect-[2/3] rounded-xl overflow-hidden glass-panel border border-white/5 select-none bg-brand-surface shadow-xl hover:ring-2 hover:ring-emerald-500/50 transition-all cursor-pointer">
@@ -836,12 +819,7 @@ export function WatchlistsDashboard() {
               <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 sm:gap-6">
                 {activeFolder.items.map(item => {
                   const isWatched = watched.some((w) => w.tmdb_id === String(item.movie.tmdb_id || '') && w.media_type === (item.movie.type === 'show' ? 'tv' : 'movie'));
-                  const cleanPosterUrl = safeImgUrl(item.movie.poster_url);
-                  const displayPosterUrl = typeof cleanPosterUrl === 'string' && (
-                    SAFE_URL_PATTERN.test(cleanPosterUrl) || 
-                    SAFE_DATA_URL_PATTERN.test(cleanPosterUrl) ||
-                    (IS_DEV && SAFE_LOCAL_URL_PATTERN.test(cleanPosterUrl))
-                  ) ? cleanPosterUrl : '';
+                  const displayPosterUrl = safeImgUrl(item.movie.poster_url);
 
                   return (
                     <div
@@ -951,14 +929,7 @@ export function WatchlistsDashboard() {
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
               {folders.map((folder, index) => {
                 const heroItem = folder.items[0];
-                const topPosters = folder.items.slice(0, 3).map(item => {
-                  const cleanPoster = safeImgUrl(item.movie?.poster_url);
-                  return typeof cleanPoster === 'string' && (
-                    SAFE_URL_PATTERN.test(cleanPoster) || 
-                    SAFE_DATA_URL_PATTERN.test(cleanPoster) ||
-                    (IS_DEV && SAFE_LOCAL_URL_PATTERN.test(cleanPoster))
-                  ) ? cleanPoster : '';
-                }).filter(Boolean) as string[];
+                const topPosters = folder.items.slice(0, 3).map(item => safeImgUrl(item.movie?.poster_url)).filter(Boolean) as string[];
                 return (
                   <div
                     key={folder.id}

--- a/pages/WatchlistsDashboard.tsx
+++ b/pages/WatchlistsDashboard.tsx
@@ -27,6 +27,14 @@ import { emitClientEvent } from '../services/clientObservability';
 import { apiPost } from '../lib/apiClient';
 import { safeImgUrl } from '../lib/seo';
 
+const SAFE_URL_PATTERN = /^(?:https?:\/\/(?:image\.tmdb\.org|static\.tvmaze\.com|images\.unsplash\.com|(?:[a-zA-Z0-9-]+\.)*googleusercontent\.com|graph\.facebook\.com|avatars\.githubusercontent\.com|moviemonk-ai\.vercel.app|(?:[a-zA-Z0-9-]+\.)*supabase\.co)\/|\/(?!\/))/i;
+const SAFE_DATA_URL_PATTERN = /^data:image\/(?:jpeg|png|webp|gif|svg\+xml);base64,[a-zA-Z0-9+/=]+$/i;
+const SAFE_LOCAL_URL_PATTERN = /^https?:\/\/localhost(?::\d+)?\//i;
+
+const IS_DEV = typeof process !== 'undefined'
+  ? (process.env?.NODE_ENV === 'development' || process.env?.NODE_ENV === 'test')
+  : (typeof window !== 'undefined' && (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'));
+
 function DashboardLayout({ children }: { children: React.ReactNode }) {
   const navigate = useNavigate();
   return (
@@ -493,31 +501,11 @@ export function WatchlistsDashboard() {
   }
 
   const cleanAvatarUrl = safeImgUrl(avatarUrl);
-  let isAvatarSafe = false;
-  if (cleanAvatarUrl) {
-    if (cleanAvatarUrl.startsWith('/') && !cleanAvatarUrl.startsWith('//')) {
-      isAvatarSafe = true;
-    } else if (cleanAvatarUrl.startsWith('data:image/')) {
-      isAvatarSafe = true;
-    } else {
-      try {
-        const parsed = new URL(cleanAvatarUrl);
-        const host = parsed.hostname.toLowerCase();
-        if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
-          isAvatarSafe = [
-            'image.tmdb.org',
-            'static.tvmaze.com',
-            'images.unsplash.com',
-            'lh3.googleusercontent.com',
-            'graph.facebook.com',
-            'avatars.githubusercontent.com',
-            'moviemonk-ai.vercel.app',
-            'localhost'
-          ].includes(host) || host.endsWith('.supabase.co');
-        }
-      } catch {}
-    }
-  }
+  const isAvatarSafe = typeof cleanAvatarUrl === 'string' && (
+    SAFE_URL_PATTERN.test(cleanAvatarUrl) || 
+    SAFE_DATA_URL_PATTERN.test(cleanAvatarUrl) ||
+    (IS_DEV && SAFE_LOCAL_URL_PATTERN.test(cleanAvatarUrl))
+  );
   const displayAvatarUrl = isAvatarSafe ? cleanAvatarUrl : '';
 
   return (
@@ -726,11 +714,11 @@ export function WatchlistsDashboard() {
             <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 sm:gap-6">
               {watched.map((item) => {
                 const cleanPosterUrl = safeImgUrl(item.poster_url);
-                const displayPosterUrl = (cleanPosterUrl.startsWith('/') && !cleanPosterUrl.startsWith('//')) ||
-                  cleanPosterUrl.startsWith('https://image.tmdb.org/') ||
-                  cleanPosterUrl.startsWith('https://static.tvmaze.com/') ||
-                  cleanPosterUrl.startsWith('https://images.unsplash.com/') ||
-                  cleanPosterUrl.startsWith('data:image/') ? cleanPosterUrl : '';
+                const displayPosterUrl = typeof cleanPosterUrl === 'string' && (
+                  SAFE_URL_PATTERN.test(cleanPosterUrl) || 
+                  SAFE_DATA_URL_PATTERN.test(cleanPosterUrl) ||
+                  (IS_DEV && SAFE_LOCAL_URL_PATTERN.test(cleanPosterUrl))
+                ) ? cleanPosterUrl : '';
 
                 return (
                   <div key={`${item.tmdb_id}-${item.media_type}`} className="group relative aspect-[2/3] rounded-xl overflow-hidden glass-panel border border-white/5 select-none bg-brand-surface shadow-xl hover:ring-2 hover:ring-emerald-500/50 transition-all cursor-pointer">
@@ -849,11 +837,11 @@ export function WatchlistsDashboard() {
                 {activeFolder.items.map(item => {
                   const isWatched = watched.some((w) => w.tmdb_id === String(item.movie.tmdb_id || '') && w.media_type === (item.movie.type === 'show' ? 'tv' : 'movie'));
                   const cleanPosterUrl = safeImgUrl(item.movie.poster_url);
-                  const displayPosterUrl = (cleanPosterUrl.startsWith('/') && !cleanPosterUrl.startsWith('//')) ||
-                    cleanPosterUrl.startsWith('https://image.tmdb.org/') ||
-                    cleanPosterUrl.startsWith('https://static.tvmaze.com/') ||
-                    cleanPosterUrl.startsWith('https://images.unsplash.com/') ||
-                    cleanPosterUrl.startsWith('data:image/') ? cleanPosterUrl : '';
+                  const displayPosterUrl = typeof cleanPosterUrl === 'string' && (
+                    SAFE_URL_PATTERN.test(cleanPosterUrl) || 
+                    SAFE_DATA_URL_PATTERN.test(cleanPosterUrl) ||
+                    (IS_DEV && SAFE_LOCAL_URL_PATTERN.test(cleanPosterUrl))
+                  ) ? cleanPosterUrl : '';
 
                   return (
                     <div
@@ -965,11 +953,11 @@ export function WatchlistsDashboard() {
                 const heroItem = folder.items[0];
                 const topPosters = folder.items.slice(0, 3).map(item => {
                   const cleanPoster = safeImgUrl(item.movie?.poster_url);
-                  return (cleanPoster.startsWith('/') && !cleanPoster.startsWith('//')) ||
-                    cleanPoster.startsWith('https://image.tmdb.org/') ||
-                    cleanPoster.startsWith('https://static.tvmaze.com/') ||
-                    cleanPoster.startsWith('https://images.unsplash.com/') ||
-                    cleanPoster.startsWith('data:image/') ? cleanPoster : '';
+                  return typeof cleanPoster === 'string' && (
+                    SAFE_URL_PATTERN.test(cleanPoster) || 
+                    SAFE_DATA_URL_PATTERN.test(cleanPoster) ||
+                    (IS_DEV && SAFE_LOCAL_URL_PATTERN.test(cleanPoster))
+                  ) ? cleanPoster : '';
                 }).filter(Boolean) as string[];
                 return (
                   <div

--- a/services/hybridDataService.ts
+++ b/services/hybridDataService.ts
@@ -11,6 +11,7 @@
  */
 
 import { MovieData } from '../types';
+import { stripHtmlTags } from '../lib/seo';
 import { ParsedQuery } from './queryParser';
 import { getFromTMDB } from './tmdbService';
 import {
@@ -81,7 +82,7 @@ export async function fetchFromBestSource(
                                 runtime: e.runtime,
                                 rating: e.rating.average,
                                 image: e.image?.original || null,
-                                summary: e.summary ? e.summary.replace(/<[^>]*>/g, '') : null
+                                summary: e.summary ? stripHtmlTags(e.summary) : null
                             }));
                         }
 
@@ -92,7 +93,7 @@ export async function fetchFromBestSource(
                                 // Focus on this specific episode
                                 movieData.title = `${tvmazeShow.name} - S${String(parsed.season).padStart(2, '0')}E${String(parsed.episode).padStart(2, '0')}: ${episodeData.name}`;
                                 movieData.summary_short = episodeData.summary ?
-                                    episodeData.summary.replace(/<[^>]*>/g, '').substring(0, 200) + '...' :
+                                    stripHtmlTags(episodeData.summary).substring(0, 200) + '...' :
                                     movieData.summary_short;
                             }
                         }

--- a/services/queryParser.ts
+++ b/services/queryParser.ts
@@ -570,7 +570,7 @@ export function parseQuery(query: string): ParsedQuery {
   // Clean up common noise and action words
   const noiseRegex = /\b(movie|moive|film|movies|show|series|serees|seris|tv|tv\s+show|tv\s+series|watch|online|free|download|hd|1080p|4k)\b/gi;
   remaining = remaining
-    .replace(noiseRegex, '')
+    .replace(noiseRegex, ' ')
     .replace(/\s+/g, ' ')
     .trim();
 

--- a/services/tvmazeService.ts
+++ b/services/tvmazeService.ts
@@ -199,12 +199,14 @@ export function stripHTML(html: string | null): string {
     if (!html) return '';
     // Strip HTML tags using robust sanitizer
     const stripped = stripHtmlTags(html);
-    // Decode only safe entities, avoiding brackets that could form tags
-    return stripped
-        .replace(/&amp;/g, '&')
-        .replace(/&quot;/g, '"')
-        .replace(/&#039;/g, "'")
-        .replace(/&apos;/g, "'");
+    // Decode only safe entities in a single pass to prevent double escaping/unescaping
+    const entityMap: Record<string, string> = {
+        '&quot;': '"',
+        '&#039;': "'",
+        '&apos;': "'",
+        '&amp;': '&'
+    };
+    return stripped.replace(/&(quot|#039|apos|amp);/g, (match) => entityMap[match] || match);
 }
 
 /**

--- a/services/tvmazeService.ts
+++ b/services/tvmazeService.ts
@@ -197,15 +197,17 @@ export async function getEpisode(
  */
 export function stripHTML(html: string | null): string {
     if (!html) return '';
-    // Decode common entities first
-    const decoded = html
-        .replace(/&amp;/g, '&')
-        .replace(/&lt;/g, '<')
-        .replace(/&gt;/g, '>')
-        .replace(/&quot;/g, '"')
-        .replace(/&#039;/g, "'")
-        .replace(/&apos;/g, "'")
-        .replace(/&nbsp;/g, ' ');
+    const entityMap: Record<string, string> = {
+        amp: '&',
+        lt: '<',
+        gt: '>',
+        quot: '"',
+        '#039': "'",
+        apos: "'",
+        nbsp: ' '
+    };
+    // Decode common entities in a single pass using a regex to prevent double-unescaping
+    const decoded = html.replace(/&(amp|lt|gt|quot|#039|apos|nbsp);/g, (match, entity) => entityMap[entity] || match);
     // Then strip HTML tags using robust sanitizer
     return stripHtmlTags(decoded);
 }

--- a/services/tvmazeService.ts
+++ b/services/tvmazeService.ts
@@ -197,16 +197,17 @@ export async function getEpisode(
  */
 export function stripHTML(html: string | null): string {
     if (!html) return '';
-    // Strip HTML tags using robust sanitizer
-    const stripped = stripHtmlTags(html);
-    // Decode only safe entities in a single pass to prevent double escaping/unescaping
-    const entityMap: Record<string, string> = {
-        '&quot;': '"',
-        '&#039;': "'",
-        '&apos;': "'",
-        '&amp;': '&'
-    };
-    return stripped.replace(/&(quot|#039|apos|amp);/g, (match) => entityMap[match] || match);
+    // Decode common entities first
+    const decoded = html
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&#039;/g, "'")
+        .replace(/&apos;/g, "'")
+        .replace(/&nbsp;/g, ' ');
+    // Then strip HTML tags using robust sanitizer
+    return stripHtmlTags(decoded);
 }
 
 /**

--- a/services/tvmazeService.ts
+++ b/services/tvmazeService.ts
@@ -1,3 +1,5 @@
+import { stripHtmlTags } from '../lib/seo';
+
 /**
  * TVMaze API Service
  * FREE API with comprehensive TV show data (no API key needed!)
@@ -195,13 +197,14 @@ export async function getEpisode(
  */
 export function stripHTML(html: string | null): string {
     if (!html) return '';
-    return html
-        .replace(/<[^>]*>/g, '') // Remove HTML tags
+    // Strip HTML tags using robust sanitizer
+    const stripped = stripHtmlTags(html);
+    // Decode only safe entities, avoiding brackets that could form tags
+    return stripped
         .replace(/&amp;/g, '&')
-        .replace(/&lt;/g, '<')
-        .replace(/&gt;/g, '>')
         .replace(/&quot;/g, '"')
-        .trim();
+        .replace(/&#039;/g, "'")
+        .replace(/&apos;/g, "'");
 }
 
 /**


### PR DESCRIPTION
This pull request addresses 16 security alerts identified by CodeQL analysis:

1. Cross-Site Scripting (XSS):
   - Refactored `stripHTML` and HTML entity decoding in `services/tvmazeService.ts` to implement robust sanitization before rendering dynamic content.
   - Integrated `stripHtmlTags` in `services/hybridDataService.ts` and `components/TVShowDisplay.tsx` to handle user-supplied/external HTML content safely.
   
2. Safe URL Handling:
   - Added validation via `safeImgUrl` in `lib/seo.ts` to ensure only trusted external image domains (e.g., tmdb.org, unsplash.com) or relative paths are loaded.
   - Wrapped poster, banner, and user avatar URLs in `components/DynamicSearchIsland.tsx`, `pages/WatchlistsDashboard.tsx`, and `pages/SettingsPages.tsx` using `safeImgUrl` to mitigate potential SSRF/untrusted URL injection vulnerabilities.

3. Query Parsing Sanitation:
   - Enhanced `services/queryParser.ts` to replace noise-matched words cleanly with spaces, preventing potential regex parsing bugs or sanitization bypasses.

No emojis are included. Build, lint, and all test suites have passed successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Safer image handling across the app: image URLs are now validated/sanitized before display (avatars, posters, banners, list heroes) to avoid unsafe or broken images.
  * Standardized HTML cleanup: episode and show text use a shared HTML-stripping routine for cleaner, consistent summaries.
  * Query parsing refined: noise-term removal preserves word boundaries to prevent accidental word concatenation in searches.

* **Tests**
  * Added test coverage for image URL validation and allowed/rejected URL cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mfscpayload-690/moviemonk-ai/pull/308?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->