### PR TITLE
Refactor: Strict Type Safety for Person Profiles

### DIFF
--- a/App-Responsive.tsx
+++ b/App-Responsive.tsx
@@ -8,7 +8,7 @@ import ActionToast from './components/ActionToast';
 import { AuthButton } from './components/AuthButton';
 import { MigrationModal } from './components/MigrationModal';
 import { NoticeDialog } from './components/BrandedDialogs';
-import { MovieData, QueryComplexity, GroundingSource, AIProvider, SuggestionItem, WatchedTitle, WatchlistSaveReceipt } from './types';
+import { MovieData, QueryComplexity, GroundingSource, AIProvider, SuggestionItem, WatchedTitle, WatchlistSaveReceipt, PersonProfile } from './types';
 import { isSupabaseConfigured, supabase } from './lib/supabase';
 import { apiGet, apiPost } from './lib/apiClient';
 import { CheckIcon, ClipboardIcon, EditIcon, Logo, TrashIcon, XMarkIcon, GithubIcon } from './components/icons';
@@ -66,7 +66,7 @@ const App: React.FC = () => {
   }, []);
 
   const [movieData, setMovieData] = useState<MovieData | null>(null);
-  const [personData, setPersonData] = useState<any | null>(null);
+  const [personData, setPersonData] = useState<PersonProfile | null>(null);
   const [selectedProvider, setSelectedProvider] = useState<AIProvider>('groq');
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
@@ -418,8 +418,8 @@ const App: React.FC = () => {
         ? `${window.location.origin}/${routePrefix}/${movieData.tmdb_id}`
         : `${window.location.origin}?q=${encodeURIComponent(movieData.title)}&type=${isTvShow ? 'show' : 'movie'}&year=${movieData.year}`;
     } else if (personData) {
-      const personName = personData?.person?.name || personData?.name || '';
-      const personId = personData?.person?.id || personData?.id;
+      const personName = personData?.person?.name || '';
+      const personId = personData?.person?.id;
       shareUrl += `?q=${encodeURIComponent(personName)}&type=person&id=${personId}`;
     } else {
       return; // Only share when a specific title or person is open
@@ -432,7 +432,7 @@ const App: React.FC = () => {
 
       track('share_link_copied', {
         type: movieData ? 'movie' : 'person',
-        title: movieData?.title || personData?.person?.name || personData?.name || ''
+        title: movieData?.title || personData?.person?.name || ''
       });
     } catch (err) {
       emitClientError(err, { context: 'copy_share_link' });

--- a/__tests__/components/personDisplay.test.ts
+++ b/__tests__/components/personDisplay.test.ts
@@ -24,12 +24,12 @@ import {
   sortPersonCredits,
   toOpenTitlePayload,
   toQuickSaveTitle,
-  truncateBiography,
-  PersonPayload
+  truncateBiography
 } from '../../components/PersonDisplay';
+import { PersonProfile } from '../../types';
 
 describe('PersonDisplay helpers', () => {
-  const payload: PersonPayload = {
+  const payload: PersonProfile = {
     person: {
       id: 9,
       name: 'Sample Person'

--- a/__tests__/components/personDisplayLayout.test.ts
+++ b/__tests__/components/personDisplayLayout.test.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import PersonDisplay, { PersonPayload } from '../../components/PersonDisplay';
+import PersonDisplay from '../../components/PersonDisplay';
+import { PersonProfile } from '../../types';
 
 jest.mock('../../components/icons', () => ({
   BirthdayIcon: () => React.createElement('span', null, 'B'),
@@ -19,7 +20,7 @@ jest.mock('@vercel/analytics/react', () => ({
 }));
 
 describe('PersonDisplay layout', () => {
-  const payload: PersonPayload = {
+  const payload: PersonProfile = {
     person: {
       id: 99,
       name: 'Chris Hemsworth',
@@ -79,7 +80,7 @@ describe('PersonDisplay layout', () => {
   });
 
   it('renders professional empty states when optional data is unavailable', () => {
-    const emptyPayload: PersonPayload = {
+    const emptyPayload: PersonProfile = {
       person: {
         id: 100,
         name: 'No Data Person'

--- a/components/PersonDisplay.tsx
+++ b/components/PersonDisplay.tsx
@@ -11,49 +11,12 @@ import {
   X
 } from 'lucide-react';
 import { useRenderCounter } from '../lib/perfDebug';
-import { PersonCredit, PersonRoleBucket, WatchlistFolder } from '../types';
+import { PersonCredit, PersonRoleBucket, WatchlistFolder, PersonProfile, FilmItem } from '../types';
 import type { QuickSaveTitle } from '../lib/quickSave';
 import { buildPersonCardPresentation } from '../services/personPresentation';
 import { TagIcon, WatchedIcon } from './icons';
 import SeoHead from './SeoHead';
 import { buildPersonJsonLd, toMetaDescription } from '../lib/seo';
-
-interface FilmItem {
-  id: number;
-  title: string;
-  year?: number;
-  role: string;
-  media_type?: 'movie' | 'tv';
-  role_bucket?: PersonRoleBucket;
-  character?: string;
-  poster_url?: string;
-  popularity?: number;
-  job?: string;
-  department?: string;
-}
-
-export interface PersonPayload {
-  person: {
-    id: number;
-    name: string;
-    biography?: string;
-    birthday?: string;
-    place_of_birth?: string;
-    profile_url?: string;
-    known_for_department?: string;
-  };
-  filmography: FilmItem[];
-  top_work?: FilmItem[];
-  credits_all?: FilmItem[];
-  credits_acting?: FilmItem[];
-  credits_directing?: FilmItem[];
-  credits_other?: FilmItem[];
-  role_distribution?: { acting: number; directing: number; other: number };
-  career_span?: { start_year?: number; end_year?: number; active_years?: number };
-  known_for_tags?: string[];
-  sources?: { name: string; url: string }[];
-  related_people?: { id: number; name: string; profile_url?: string; known_for?: string }[];
-}
 
 type PersonCreditBuckets = {
   allCredits: PersonCredit[];
@@ -75,7 +38,7 @@ export type DisplayCredit = PersonCredit & {
   roleCount: number;
 };
 
-export function derivePersonCreditBuckets(data: PersonPayload): PersonCreditBuckets {
+export function derivePersonCreditBuckets(data: PersonProfile): PersonCreditBuckets {
   const normalizedFallback = (data.filmography || []).map((item) => {
     const roleLower = String(item.role || item.job || '').toLowerCase();
     let bucket: PersonRoleBucket = 'other';
@@ -393,7 +356,7 @@ function formatBirthDate(birthdayStr: string): string {
 }
 
 const PersonHero: React.FC<{
-  person: PersonPayload['person'];
+  person: PersonProfile['person'];
   tags: string[];
   topWork: DisplayCredit[];
   biographyExcerpt: string;
@@ -762,7 +725,7 @@ const CreditsExplorer: React.FC<{
 };
 
 const RelatedPeopleRail: React.FC<{
-  relatedPeople?: PersonPayload['related_people'];
+  relatedPeople?: PersonProfile['related_people'];
   onOpenPerson?: (id: number, name: string) => void;
   onQuickSearch?: (q: string) => void;
 }> = ({ relatedPeople, onOpenPerson, onQuickSearch }) => (
@@ -811,7 +774,7 @@ const RelatedPeopleRail: React.FC<{
   </section>
 );
 
-const SourcesSection: React.FC<{ sources?: PersonPayload['sources'] }> = ({ sources }) => (
+const SourcesSection: React.FC<{ sources?: PersonProfile['sources'] }> = ({ sources }) => (
   <section className="person-editorial-section person-sources-section" aria-labelledby="person-sources-title">
     <header>
       <h3 id="person-sources-title">Sources</h3>
@@ -999,7 +962,7 @@ const PersonLoadingSkeleton: React.FC = () => (
 );
 
 const PersonDisplay: React.FC<{
-  data: PersonPayload | null;
+  data: PersonProfile | null;
   isLoading?: boolean;
   onQuickSearch?: (q: string) => void;
   onBriefMe?: (name: string) => void;

--- a/types.ts
+++ b/types.ts
@@ -101,6 +101,20 @@ export interface PersonSearchCandidate {
   profile_url?: string;
 }
 
+export interface FilmItem {
+  id: number;
+  title: string;
+  year?: number;
+  role: string;
+  media_type?: 'movie' | 'tv';
+  role_bucket?: PersonRoleBucket;
+  character?: string;
+  poster_url?: string;
+  popularity?: number;
+  job?: string;
+  department?: string;
+}
+
 export interface PersonProfile {
   person: {
     id: number;
@@ -111,22 +125,26 @@ export interface PersonProfile {
     profile_url?: string;
     known_for_department?: string;
   };
-  top_work: PersonCredit[];
-  credits_all: PersonCredit[];
-  credits_acting: PersonCredit[];
-  credits_directing: PersonCredit[];
-  credits_other: PersonCredit[];
-  role_distribution: {
+  filmography: FilmItem[];
+  top_work?: PersonCredit[];
+  credits_all?: PersonCredit[];
+  credits_acting?: PersonCredit[];
+  credits_directing?: PersonCredit[];
+  credits_other?: PersonCredit[];
+  role_distribution?: {
     acting: number;
     directing: number;
     other: number;
   };
-  career_span: {
+  career_span?: {
     start_year?: number;
     end_year?: number;
     active_years?: number;
   };
-  known_for_tags: string[];
+  known_for_tags?: string[];
+  sources?: { name: string; url: string }[];
+  related_people?: RelatedPerson[];
+  cached?: boolean;
 }
 
 // Related content types for Similar/People Also Search
@@ -137,7 +155,7 @@ export type RelatedTitle = {
   media_type: 'movie' | 'tv';
   poster_url?: string;
   popularity?: number;
-  source: 'tmdb-similar' | 'tmdb-recommendations' | 'serpapi';
+  source?: 'tmdb-similar' | 'tmdb-recommendations' | 'serpapi';
 };
 
 export type RelatedPerson = {
@@ -146,7 +164,7 @@ export type RelatedPerson = {
   known_for?: string;
   profile_url?: string;
   popularity?: number;
-  source: 'tmdb-co-star' | 'tmdb-similar' | 'serpapi';
+  source?: 'tmdb-co-star' | 'tmdb-similar' | 'serpapi';
 };
 
 export interface Rating {


### PR DESCRIPTION
Consolidates duplicate PersonPayload types into a centralized PersonProfile inside types.ts and types state variables strictly, removing the use of 'any'.